### PR TITLE
fixes data race that sometimes causes a badger nil panic due to a race on the transaction

### DIFF
--- a/badger/query.go
+++ b/badger/query.go
@@ -53,9 +53,6 @@ func (b BadgerBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch
 					defer txMx.Unlock()
 					it := txn.NewIterator(opts)
 					iteratorClosers[i] = it.Close
-
-					defer close(q.results)
-
 					for it.Seek(q.startingPoint); it.ValidForPrefix(q.prefix); it.Next() {
 						item := it.Item()
 						key := item.Key()
@@ -128,6 +125,10 @@ func (b BadgerBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch
 				defer txMx.Unlock()
 				for _, itclose := range iteratorClosers {
 					itclose()
+				}
+				// this is the correct time to close the results channels
+				for _, q := range queries {
+					close(q.results)
 				}
 			}()
 


### PR DESCRIPTION
the transaction is accessed by the iterator closing deferred function as well as by the queries goroutine loop

most of the time this probably doesn't race, in my tests it was hit and miss but adding a mutex to accesses to the txn within the View iterator eliminates the races

this race can cause the QuerySync call in the relay_interface.go to fail to receive all of the transactions due to the race sometimes happening and failing to send a result back over the channel, this should not happen now