### PR TITLE
Allows for running in arm64 and windows (and maybe other platforms) by allowing to configure MapSize

### DIFF
--- a/lmdb/lib.go
+++ b/lmdb/lib.go
@@ -19,6 +19,7 @@ var _ eventstore.Store = (*LMDBBackend)(nil)
 type LMDBBackend struct {
 	Path     string
 	MaxLimit int
+	MapSize int
 
 	lmdbEnv *lmdb.Env
 
@@ -49,7 +50,12 @@ func (b *LMDBBackend) Init() error {
 
 	env.SetMaxDBs(10)
 	env.SetMaxReaders(1000)
-	env.SetMapSize(1 << 38) // ~273GB
+	if b.MapSize == 0 {
+		env.SetMapSize(1 << 38) // ~273GB
+	} else {
+		env.SetMapSize(b.MapSize)
+		fmt.Printf("MapSize: %d\n", b.MapSize)
+	}
 
 	// create directory if it doesn't exist and open it
 	if err := os.MkdirAll(b.Path, 0755); err != nil {

--- a/lmdb/lib.go
+++ b/lmdb/lib.go
@@ -19,7 +19,7 @@ var _ eventstore.Store = (*LMDBBackend)(nil)
 type LMDBBackend struct {
 	Path     string
 	MaxLimit int
-	MapSize int
+	MapSize int64
 
 	lmdbEnv *lmdb.Env
 

--- a/lmdb/lib.go
+++ b/lmdb/lib.go
@@ -54,7 +54,6 @@ func (b *LMDBBackend) Init() error {
 		env.SetMapSize(1 << 38) // ~273GB
 	} else {
 		env.SetMapSize(b.MapSize)
-		fmt.Printf("MapSize: %d\n", b.MapSize)
 	}
 
 	// create directory if it doesn't exist and open it


### PR DESCRIPTION
The default env.SetMapSize(1 << 38) throws an error in windows and arm64 machines with low disk space. Allowing a param in "LMDBBackend" to set a lower value helps to run pools with lmdb in architectures other than linux x86/x64 (tested in windows and in linux arm64, probably will help for other architectures too).