### PR TITLE
fix checking errors "Duplicate key name" for mysql

### DIFF
--- a/mysql/init.go
+++ b/mysql/init.go
@@ -48,7 +48,7 @@ func (b *MySQLBackend) Init() error {
 
 	for _, ddl := range ddls {
 		_, err := b.DB.Exec(ddl)
-		if err != nil && !strings.HasPrefix(err.Error(), `Error 1061: Duplicate key name`) {
+		if err != nil && !strings.HasPrefix(err.Error(), `Duplicate key name`) {
 			return err
 		}
 	}


### PR DESCRIPTION
Some versions of mysql returns

>Error 1061 (42000): Duplicate key name

But some versions returns

> Error 1061: Duplicate key nam