### PR TITLE
Allow to use a previously connected psql DB

### DIFF
--- a/postgresql/init.go
+++ b/postgresql/init.go
@@ -24,7 +24,6 @@ func (b *PostgresBackend) Init() error {
             return err
         }
     }
-on
 	// sqlx default is 0 (unlimited), while postgresql by default accepts up to 100 connections
 	db.SetMaxOpenConns(80)
 


### PR DESCRIPTION
The usecase is if we want to use some kind of sql tracing like
https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/database/sql
https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/jmoiron/sqlx
and want to create the DB instance before calling `Init()`:
```	
        sqlDb, err := sqlxtrace.Open("postgres", cfg.DatabaseUri)
	r.Storage = &postgresql.PostgresBackend{DB: sqlDb}
	err = r.Storage.Init()
```
the checking for DB == nil and only in that case use `DatabaseURL` and connect to it would help achieve this.