### PR TITLE
Increase default tags limit

### DIFF
--- a/edgedb/init.go
+++ b/edgedb/init.go
@@ -15,7 +15,7 @@ const (
 	queryIDsLimit     = 500
 	queryAuthorsLimit = 500
 	queryKindsLimit   = 10
-	queryTagsLimit    = 10
+	queryTagsLimit    = 100
 )
 
 var (

--- a/mongo/init.go
+++ b/mongo/init.go
@@ -14,7 +14,7 @@ const (
 	queryIDsLimit     = 500
 	queryAuthorsLimit = 500
 	queryKindsLimit   = 10
-	queryTagsLimit    = 10
+	queryTagsLimit    = 100
 )
 
 var indexs = []mongo.IndexModel{

--- a/mysql/init.go
+++ b/mysql/init.go
@@ -14,7 +14,7 @@ const (
 	queryIDsLimit     = 500
 	queryAuthorsLimit = 500
 	queryKindsLimit   = 10
-	queryTagsLimit    = 10
+	queryTagsLimit    = 100
 )
 
 var _ eventstore.Store = (*MySQLBackend)(nil)

--- a/postgresql/init.go
+++ b/postgresql/init.go
@@ -12,7 +12,7 @@ const (
 	queryIDsLimit     = 500
 	queryAuthorsLimit = 500
 	queryKindsLimit   = 10
-	queryTagsLimit    = 10
+	queryTagsLimit    = 100
 )
 
 var _ eventstore.Store = (*PostgresBackend)(nil)

--- a/sqlite3/init.go
+++ b/sqlite3/init.go
@@ -12,7 +12,7 @@ const (
 	queryIDsLimit     = 500
 	queryAuthorsLimit = 500
 	queryKindsLimit   = 10
-	queryTagsLimit    = 10
+	queryTagsLimit    = 100
 )
 
 var _ eventstore.Store = (*SQLite3Backend)(nil)


### PR DESCRIPTION
The limit of 10 is absurdly low, and there are lots of use cases where more tag values make sense, particularly for getting replies/deletes for notes (`#e`). This was also breaking my pagination for calendar events using `#D`