### PR TITLE
fix(postgresql): prefix tagvalues with tag key for correct NIP-01 filtering

### DIFF
--- a/postgresql/init.go
+++ b/postgresql/init.go
@@ -35,7 +35,7 @@ func (b *PostgresBackend) Init() error {
 
 	_, err = b.DB.Exec(`
 CREATE OR REPLACE FUNCTION tags_to_tagvalues(jsonb) RETURNS text[]
-    AS 'SELECT array_agg(t->>1) FROM (SELECT jsonb_array_elements($1) AS t)s WHERE length(t->>0) = 1;'
+    AS 'SELECT COALESCE(array_agg((t->>0) || '':'' || (t->>1)), ''{}''::text[]) FROM (SELECT jsonb_array_elements($1) AS t)s WHERE length(t->>0) = 1;'
     LANGUAGE SQL
     IMMUTABLE
     RETURNS NULL ON NULL INPUT;

--- a/postgresql/query.go
+++ b/postgresql/query.go
@@ -112,7 +112,7 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	}
 
 	totalTags := 0
-	for _, values := range filter.Tags {
+	for tagKey, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
 			return "", nil, EmptyTagSet
@@ -125,7 +125,7 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 		}
 
 		for _, tagValue := range values {
-			params = append(params, tagValue)
+			params = append(params, strings.TrimPrefix(tagKey, "#")+":"+tagValue)
 		}
 
 		// each separate tag key is an independent condition

--- a/postgresql/query_test.go
+++ b/postgresql/query_test.go
@@ -137,6 +137,21 @@ func TestQueryEventsSql(t *testing.T) {
 			err:    EmptyTagSet,
 		},
 		{
+			name:    "tag filter with key prefix",
+			backend: defaultBackend,
+			filter: nostr.Filter{
+				Tags: nostr.TagMap{
+					"#e": {"abc123"},
+				},
+			},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE tagvalues && ARRAY[$1]
+			ORDER BY created_at DESC, id LIMIT $2`,
+			params: []any{"e:abc123", 100},
+			err:    nil,
+		},
+		{
 			name:    "too many tag values",
 			backend: defaultBackend,
 			filter: nostr.Filter{


### PR DESCRIPTION
## Summary

- `tags_to_tagvalues()` now produces key-prefixed values (`"e:abc123"` instead of `"abc123"`)
- `queryEventsSql()` prepends the tag key when building filter params (`strings.TrimPrefix(tagKey, "#") + ":" + tagValue`)
- Added test case verifying `#e` filter produces `"e:abc123"` in query params

This ensures that a `#e` filter only matches `e`-tagged values, not `p` or `t` tags that happen to share the same value. The GIN index works identically with prefixed values.

**Breaking change**: existing `tagvalues` data must be recomputed. Since `tagvalues` is a `GENERATED ALWAYS AS` column, this requires dropping and recreating the column (or recreating the table).

Fixes #55