### PR TITLE
use b.QueryKindsLimit in sqlite3 query

### DIFF
--- a/sqlite3/query.go
+++ b/sqlite3/query.go
@@ -100,7 +100,7 @@ func (b SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (strin
 	}
 
 	if len(filter.Kinds) > 0 {
-		if len(filter.Kinds) > 10 {
+		if len(filter.Kinds) > b.QueryKindsLimit {
 			// too many kinds, fail everything
 			return "", nil, TooManyKinds
 		}


### PR DESCRIPTION
Fixes #48

The kinds count was compared against a hard-coded 10 instead of the configurable `b.QueryKindsLimit`.