### PR TITLE
fix migration 5 transaction overflow on large datasets

### DIFF
--- a/badger/migrations.go
+++ b/badger/migrations.go
@@ -11,63 +11,70 @@ import (
 )
 
 func (b *BadgerBackend) runMigrations() error {
-	return b.Update(func(txn *badger.Txn) error {
-		var version uint16
-
+	var version uint16
+	if err := b.View(func(txn *badger.Txn) error {
 		item, err := txn.Get([]byte{dbVersionKey})
 		if err == badger.ErrKeyNotFound {
-			version = 0
+			return nil
 		} else if err != nil {
 			return err
-		} else {
-			item.Value(func(val []byte) error {
-				version = binary.BigEndian.Uint16(val)
-				return nil
-			})
+		}
+		return item.Value(func(val []byte) error {
+			version = binary.BigEndian.Uint16(val)
+			return nil
+		})
+	}); err != nil {
+		return err
+	}
+
+	// do the migrations in increasing steps (there is no rollback)
+	//
+
+	// the 5 first migrations go to trash because on version 5 we need to export and import all the data anyway
+	if version < 5 {
+		log.Println("[badger] migration 5: delete all indexes and recreate them")
+
+		// delete all index entries (in a WriteBatch so we don't blow past the txn size limit)
+		prefixes := []byte{
+			indexIdPrefix,
+			indexCreatedAtPrefix,
+			indexKindPrefix,
+			indexPubkeyPrefix,
+			indexPubkeyKindPrefix,
+			indexTagPrefix,
+			indexTag32Prefix,
+			indexTagAddrPrefix,
 		}
 
-		// do the migrations in increasing steps (there is no rollback)
-		//
-
-		// the 5 first migrations go to trash because on version 5 we need to export and import all the data anyway
-		if version < 5 {
-			log.Println("[badger] migration 5: delete all indexes and recreate them")
-
-			// delete all index entries
-			prefixes := []byte{
-				indexIdPrefix,
-				indexCreatedAtPrefix,
-				indexKindPrefix,
-				indexPubkeyPrefix,
-				indexPubkeyKindPrefix,
-				indexTagPrefix,
-				indexTag32Prefix,
-				indexTagAddrPrefix,
-			}
-
-			for _, prefix := range prefixes {
+		wb := b.NewWriteBatch()
+		for _, prefix := range prefixes {
+			err := b.View(func(txn *badger.Txn) error {
 				it := txn.NewIterator(badger.IteratorOptions{
 					PrefetchValues: false,
 					Prefix:         []byte{prefix},
 				})
 				defer it.Close()
 
-				var keysToDelete [][]byte
 				for it.Seek([]byte{prefix}); it.ValidForPrefix([]byte{prefix}); it.Next() {
-					key := it.Item().Key()
-					keyCopy := make([]byte, len(key))
-					copy(keyCopy, key)
-					keysToDelete = append(keysToDelete, keyCopy)
-				}
-
-				for _, key := range keysToDelete {
-					if err := txn.Delete(key); err != nil {
+					key := it.Item().KeyCopy(nil)
+					if err := wb.Delete(key); err != nil {
 						return fmt.Errorf("failed to delete index key %x: %w", key, err)
 					}
 				}
+				return nil
+			})
+			if err != nil {
+				wb.Cancel()
+				return err
 			}
+		}
+		if err := wb.Flush(); err != nil {
+			return fmt.Errorf("failed to flush index deletions on migration 5: %w", err)
+		}
 
-			// iterate through all events and recreate indexes
+		// recreate indexes (also in a WriteBatch)
+		wb = b.NewWriteBatch()
+		err := b.View(func(txn *badger.Txn) error {
 			it := txn.NewIterator(badger.IteratorOptions{
 				PrefetchValues: true,
 				Prefix:         []byte{rawEventStorePrefix},
@@ -76,7 +83,7 @@ func (b *BadgerBackend) runMigrations() error {
 
 			for it.Seek([]byte{rawEventStorePrefix}); it.ValidForPrefix([]byte{rawEventStorePrefix}); it.Next() {
 				item := it.Item()
-				idx := item.Key()
+				idx := item.KeyCopy(nil)
 
 				err := item.Value(func(val []byte) error {
 					evt := &nostr.Event{}
@@ -85,7 +92,7 @@ func (b *BadgerBackend) runMigrations() error {
 					}
 
 					for key := range b.getIndexKeysForEvent(evt, idx[1:]) {
-						if err := txn.Set(key, nil); err != nil {
+						if err := wb.Set(key, nil); err != nil {
 							return fmt.Errorf("failed to save index for event %s on migration 5: %w", evt.ID, err)
 						}
 					}
@@ -96,15 +103,25 @@ func (b *BadgerBackend) runMigrations() error {
 					return err
 				}
 			}
-
-			// bump version
-			if err := b.bumpVersion(txn, 5); err != nil {
-				return err
-			}
+			return nil
+		})
+		if err != nil {
+			wb.Cancel()
+			return err
+		}
+		if err := wb.Flush(); err != nil {
+			return fmt.Errorf("failed to flush index creation on migration 5: %w", err)
 		}
 
-		return nil
-	})
+		// bump version
+		if err := b.Update(func(txn *badger.Txn) error {
+			return b.bumpVersion(txn, 5)
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (b *BadgerBackend) bumpVersion(txn *badger.Txn, version uint16) error {


### PR DESCRIPTION
Fixes #47

The whole migration ran inside a single `badger.Txn`, so relays with enough events hit the per-transaction size cap and crashed with `Txn is too big to fit into one request`. The index delete and recreate passes now use `badger.WriteBatch` (which streams writes across multiple transactions) and a separate `View` transaction for iteration, keeping reads on a consistent snapshot.