### PR TITLE
Avoid copying MySQL backend

### DIFF
--- a/mysql/delete.go
+++ b/mysql/delete.go
@@ -6,7 +6,7 @@ import (
 	"github.com/nbd-wtf/go-nostr"
 )
 
-func (b MySQLBackend) DeleteEvent(ctx context.Context, evt *nostr.Event) error {
+func (b *MySQLBackend) DeleteEvent(ctx context.Context, evt *nostr.Event) error {
 	_, err := b.DB.ExecContext(ctx, "DELETE FROM event WHERE id = ?", evt.ID)
 	return err
 }

--- a/mysql/query.go
+++ b/mysql/query.go
@@ -10,7 +10,7 @@ import (
 	"github.com/nbd-wtf/go-nostr"
 )
 
-func (b MySQLBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch chan *nostr.Event, err error) {
+func (b *MySQLBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch chan *nostr.Event, err error) {
 	ch = make(chan *nostr.Event)
 
 	query, params, err := b.queryEventsSql(filter, false)
@@ -48,7 +48,7 @@ func (b MySQLBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch 
 	return ch, nil
 }
 
-func (b MySQLBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int64, error) {
+func (b *MySQLBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int64, error) {
 	query, params, err := b.queryEventsSql(filter, true)
 	if err != nil {
 		return 0, err
@@ -72,7 +72,7 @@ func escapeLikeString(s string) string {
 	return s
 }
 
-func (b MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
 
@@ -126,7 +126,6 @@ func (b MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string,
 		}
 		tag = tag + `]%`
 		params = append(params, tag)
-
 
 		// each separate tag key is an independent condition
 		conditions = append(conditions, `tags LIKE ?`)


### PR DESCRIPTION
MySQLBackend embeds a mutex, so value receivers copy the lock. This changes the query and delete methods to pointer receivers to keep the backend instance intact.