### PR TITLE
Fix disabled search queries

### DIFF
--- a/wrappers/disablesearch/disablesearch.go
+++ b/wrappers/disablesearch/disablesearch.go
@@ -15,7 +15,9 @@ var _ eventstore.Store = (*Wrapper)(nil)
 
 func (w Wrapper) QueryEvents(ctx context.Context, filter nostr.Filter) (chan *nostr.Event, error) {
 	if filter.Search != "" {
-		return nil, nil
+		ch := make(chan *nostr.Event)
+		close(ch)
+		return ch, nil
 	}
 	return w.Store.QueryEvents(ctx, filter)
 }

--- a/wrappers/disablesearch/disablesearch_test.go
+++ b/wrappers/disablesearch/disablesearch_test.go
@@ -1,0 +1,20 @@
+package disablesearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/fiatjaf/eventstore/nullstore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryEventsWithSearchReturnsClosedChannel(t *testing.T) {
+	w := eventstore.RelayWrapper{Store: Wrapper{Store: nullstore.NullStore{}}}
+
+	events, err := w.QuerySync(context.Background(), nostr.Filter{Search: "nostr"})
+
+	require.NoError(t, err)
+	require.Empty(t, events)
+}


### PR DESCRIPTION
Disabled search queries returned a nil channel with no error, which can block callers that range over the result. Return a closed channel instead so callers receive an empty result immediately.