### PR TITLE
Fix MongoDB time filters

### DIFF
--- a/mongo/query.go
+++ b/mongo/query.go
@@ -129,10 +129,10 @@ func (m *MongoDBBackend) queryEvents(filter nostr.Filter, doCount bool) (bson.D,
 		}
 	}
 	if filter.Since != nil {
-		conditions = append(conditions, bson.E{Key: "since", Value: bson.M{"$gte": filter.Since}})
+		conditions = append(conditions, bson.E{Key: "createdat", Value: bson.M{"$gte": *filter.Since}})
 	}
 	if filter.Until != nil {
-		conditions = append(conditions, bson.E{Key: "until", Value: bson.M{"$lte": filter.Until}})
+		conditions = append(conditions, bson.E{Key: "createdat", Value: bson.M{"$lte": *filter.Until}})
 	}
 	if filter.Search != "" {
 		conditions = append(conditions, bson.E{Key: "search", Value: bson.M{"$regex": filter.Search}})

--- a/mongo/query_test.go
+++ b/mongo/query_test.go
@@ -1,0 +1,44 @@
+package mongo
+
+import (
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+	"go.mongodb.org/mongo-driver/v2/bson"
+)
+
+func TestQueryEventsUsesCreatedAtForTimeFilters(t *testing.T) {
+	backend := &MongoDBBackend{
+		QueryLimit:        queryLimit,
+		QueryIDsLimit:     queryIDsLimit,
+		QueryAuthorsLimit: queryAuthorsLimit,
+		QueryKindsLimit:   queryKindsLimit,
+		QueryTagsLimit:    queryTagsLimit,
+	}
+	since := nostr.Timestamp(10)
+	until := nostr.Timestamp(20)
+
+	conditions, _, err := backend.queryEvents(nostr.Filter{
+		Since: &since,
+		Until: &until,
+	}, false)
+
+	require.NoError(t, err)
+	require.Contains(t, conditions, bson.E{
+		Key:   "createdat",
+		Value: bson.M{"$gte": since},
+	})
+	require.Contains(t, conditions, bson.E{
+		Key:   "createdat",
+		Value: bson.M{"$lte": until},
+	})
+	require.NotContains(t, conditions, bson.E{
+		Key:   "since",
+		Value: bson.M{"$gte": &since},
+	})
+	require.NotContains(t, conditions, bson.E{
+		Key:   "until",
+		Value: bson.M{"$lte": &until},
+	})
+}


### PR DESCRIPTION
MongoDB queries were filtering since and until against fields that are not stored on events. Use the stored createdat field so time filters return the expected results.