### PR TITLE
Fix DynamoDB until filter

### DIFF
--- a/dynamodb/query.go
+++ b/dynamodb/query.go
@@ -55,7 +55,7 @@ func buildBuilder(filter nostr.Filter) expression.Builder {
 		builder = builder.WithFilter(expression.Name("created_at").GreaterThanEqual(expression.Value(*filter.Since)))
 	}
 	if filter.Until != nil {
-		builder = builder.WithFilter(expression.Name("created_at").LessThan(expression.Value(*filter.Until)))
+		builder = builder.WithFilter(expression.Name("created_at").LessThanEqual(expression.Value(*filter.Until)))
 	}
 	if len(filter.Tags) > 0 {
 		tfilt := expression.ConditionBuilder{}

--- a/dynamodb/query_test.go
+++ b/dynamodb/query_test.go
@@ -1,0 +1,18 @@
+package dynamodb
+
+import (
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildBuilderUsesInclusiveUntil(t *testing.T) {
+	until := nostr.Timestamp(42)
+
+	expr, err := buildBuilder(nostr.Filter{Until: &until}).Build()
+
+	require.NoError(t, err)
+	require.NotNil(t, expr.Filter())
+	require.Contains(t, *expr.Filter(), "<=")
+}


### PR DESCRIPTION
DynamoDB queries used an exclusive comparison for until, which drops events created exactly at the boundary. Use an inclusive comparison to match the filter semantics used by the other backends.