### PR TITLE
Fix MongoDB tag filters

### DIFF
--- a/mongo/query.go
+++ b/mongo/query.go
@@ -110,7 +110,7 @@ func (m *MongoDBBackend) queryEvents(filter nostr.Filter, doCount bool) (bson.D,
 	}
 
 	totalTags := 0
-	for _, values := range filter.Tags {
+	for key, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
 			return nil, nil, ErrEmptyTagSet
@@ -120,7 +120,10 @@ func (m *MongoDBBackend) queryEvents(filter nostr.Filter, doCount bool) (bson.D,
 			tags = append(tags, tagValue)
 		}
 
-		conditions = append(conditions, bson.E{Key: "colors", Value: bson.M{"$in": tags}})
+		conditions = append(conditions, bson.E{Key: "tags", Value: bson.M{"$elemMatch": bson.M{
+			"0": key,
+			"1": bson.M{"$in": tags},
+		}}})
 
 		totalTags += len(values)
 		if totalTags > m.QueryTagsLimit {

--- a/mongo/query_test.go
+++ b/mongo/query_test.go
@@ -42,3 +42,30 @@ func TestQueryEventsUsesCreatedAtForTimeFilters(t *testing.T) {
 		Value: bson.M{"$lte": &until},
 	})
 }
+
+func TestQueryEventsUsesTagsFieldForTagFilters(t *testing.T) {
+	backend := &MongoDBBackend{
+		QueryLimit:        queryLimit,
+		QueryIDsLimit:     queryIDsLimit,
+		QueryAuthorsLimit: queryAuthorsLimit,
+		QueryKindsLimit:   queryKindsLimit,
+		QueryTagsLimit:    queryTagsLimit,
+	}
+
+	conditions, _, err := backend.queryEvents(nostr.Filter{
+		Tags: nostr.TagMap{"p": []string{"pubkey1", "pubkey2"}},
+	}, false)
+
+	require.NoError(t, err)
+	require.Contains(t, conditions, bson.E{
+		Key: "tags",
+		Value: bson.M{"$elemMatch": bson.M{
+			"0": "p",
+			"1": bson.M{"$in": bson.A{"pubkey1", "pubkey2"}},
+		}},
+	})
+	require.NotContains(t, conditions, bson.E{
+		Key:   "colors",
+		Value: bson.M{"$in": bson.A{"pubkey1", "pubkey2"}},
+	})
+}


### PR DESCRIPTION
MongoDB tag queries were filtering on a field that is not stored on events. Match tag entries inside the stored tags array so tag filters can return the expected events.