### PR TITLE
Skip replace events

### DIFF
--- a/wrappers/skipevent/skipevent.go
+++ b/wrappers/skipevent/skipevent.go
@@ -22,3 +22,11 @@ func (w Wrapper) SaveEvent(ctx context.Context, evt *nostr.Event) error {
 
 	return w.Store.SaveEvent(ctx, evt)
 }
+
+func (w Wrapper) ReplaceEvent(ctx context.Context, evt *nostr.Event) error {
+	if w.Skip(ctx, evt) {
+		return nil
+	}
+
+	return w.Store.ReplaceEvent(ctx, evt)
+}

--- a/wrappers/skipevent/skipevent_test.go
+++ b/wrappers/skipevent/skipevent_test.go
@@ -1,0 +1,34 @@
+package skipevent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/fiatjaf/eventstore/nullstore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+type replaceCountingStore struct {
+	nullstore.NullStore
+	replaces int
+}
+
+func (s *replaceCountingStore) ReplaceEvent(context.Context, *nostr.Event) error {
+	s.replaces++
+	return nil
+}
+
+func TestReplaceEventCanBeSkipped(t *testing.T) {
+	store := &replaceCountingStore{}
+	w := eventstore.RelayWrapper{Store: Wrapper{
+		Store: store,
+		Skip:  func(context.Context, *nostr.Event) bool { return true },
+	}}
+
+	err := w.Publish(context.Background(), nostr.Event{Kind: 3})
+
+	require.NoError(t, err)
+	require.Zero(t, store.replaces)
+}


### PR DESCRIPTION
The skip wrapper only intercepted SaveEvent, so replaceable events could still reach the inner store through ReplaceEvent. Apply the same skip check to ReplaceEvent so skipped events are consistently ignored.