### PR TITLE
Propagate ReplaceEvent errors from RelayWrapper.Publish

### DIFF
--- a/relay_interface.go
+++ b/relay_interface.go
@@ -31,7 +31,9 @@ func (w RelayWrapper) Publish(ctx context.Context, evt nostr.Event) error {
 	}
 
 	// others are replaced
-	w.Store.ReplaceEvent(ctx, &evt)
+	if err := w.Store.ReplaceEvent(ctx, &evt); err != nil {
+		return fmt.Errorf("failed to replace: %w", err)
+	}
 
 	return nil
 }

--- a/relay_interface_test.go
+++ b/relay_interface_test.go
@@ -1,0 +1,39 @@
+package eventstore
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+type failingReplaceStore struct{}
+
+func (failingReplaceStore) Init() error { return nil }
+
+func (failingReplaceStore) Close() {}
+
+func (failingReplaceStore) QueryEvents(context.Context, nostr.Filter) (chan *nostr.Event, error) {
+	ch := make(chan *nostr.Event)
+	close(ch)
+	return ch, nil
+}
+
+func (failingReplaceStore) DeleteEvent(context.Context, *nostr.Event) error { return nil }
+
+func (failingReplaceStore) SaveEvent(context.Context, *nostr.Event) error { return nil }
+
+func (failingReplaceStore) ReplaceEvent(context.Context, *nostr.Event) error {
+	return errors.New("replace failed")
+}
+
+func TestPublishReturnsReplaceEventErrors(t *testing.T) {
+	w := RelayWrapper{Store: failingReplaceStore{}}
+
+	err := w.Publish(context.Background(), nostr.Event{Kind: 3})
+
+	require.ErrorContains(t, err, "failed to replace")
+	require.ErrorContains(t, err, "replace failed")
+}


### PR DESCRIPTION
`RelayWrapper.Publish` discarded the error returned by `Store.ReplaceEvent` for replaceable/addressable events, silently swallowing failures and returning `nil` even when the replace failed.

This wraps and returns the error (matching the existing `failed to save` / `failed to query` style), so callers actually learn when a replace fails.

A test (`TestPublishReturnsReplaceEventErrors`) covers the new behavior with a stub store whose `ReplaceEvent` always errors.