### PR TITLE
Fix MySQL tag filters

### DIFF
--- a/mysql/query.go
+++ b/mysql/query.go
@@ -120,15 +120,14 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 			return "", nil, nil
 		}
 
-		tag := `%["` + escapeLikeString(key) + `"`
+		orTag := make([]string, 0, len(values))
 		for _, tagValue := range values {
-			tag = tag + `, "` + escapeLikeString(tagValue) + `"`
+			orTag = append(orTag, `tags LIKE ?`)
+			params = append(params, `%["`+escapeLikeString(key)+`","`+escapeLikeString(tagValue)+`"%`)
 		}
-		tag = tag + `]%`
-		params = append(params, tag)
 
 		// each separate tag key is an independent condition
-		conditions = append(conditions, `tags LIKE ?`)
+		conditions = append(conditions, `(`+strings.Join(orTag, " OR ")+`)`)
 
 		totalTags += len(values)
 		if totalTags > b.QueryTagsLimit {

--- a/mysql/query_test.go
+++ b/mysql/query_test.go
@@ -1,0 +1,27 @@
+package mysql
+
+import (
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQueryEventsSqlBuildsTagValueAlternatives(t *testing.T) {
+	backend := MySQLBackend{
+		QueryLimit:        queryLimit,
+		QueryIDsLimit:     queryIDsLimit,
+		QueryAuthorsLimit: queryAuthorsLimit,
+		QueryKindsLimit:   queryKindsLimit,
+		QueryTagsLimit:    queryTagsLimit,
+	}
+
+	query, params, err := backend.queryEventsSql(nostr.Filter{
+		Tags: nostr.TagMap{"p": []string{"pubkey1", "pubkey2"}},
+	}, false)
+
+	require.NoError(t, err)
+	require.Contains(t, query, `(tags LIKE ? OR tags LIKE ?)`)
+	require.Contains(t, params, `%["p","pubkey1"%`)
+	require.Contains(t, params, `%["p","pubkey2"%`)
+}


### PR DESCRIPTION
The MySQL backend built a single LIKE pattern that concatenated all values of a tag filter into one ordered string, so an event only matched when it happened to contain every requested value in that exact order. This made multi-value tag filters effectively unsatisfiable and mismatched the semantics of the other backends.

Each tag value now produces its own `tags LIKE ?` clause joined with OR, so a tag key matches when the event carries any of the requested values, while distinct tag keys remain ANDed together as independent conditions. A regression test covering single- and multi-value tag queries is included.

This mirrors the equivalent MongoDB tag-filter fix.