### PR TITLE
Add Turso backend

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/nbd-wtf/go-nostr v0.52.1
 	github.com/opensearch-project/opensearch-go/v4 v4.5.0
 	github.com/stretchr/testify v1.11.1
+	github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60
 	github.com/urfave/cli/v3 v3.5.0
 	go.mongodb.org/mongo-driver/v2 v2.4.0
 	golang.org/x/exp v0.0.0-20251023183803-a4bb9ffd2546
@@ -33,6 +34,7 @@ require (
 	filippo.io/edwards25519 v1.1.0 // indirect
 	github.com/ImVexed/fasturl v0.0.0-20230304231329-4e41488060f3 // indirect
 	github.com/RoaringBitmap/roaring v1.9.4 // indirect
+	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue v1.20.21 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.13 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/RoaringBitmap/roaring v0.9.4/go.mod h1:icnadbWcNyfEHlYdr+tDlOTih1Bf/h
 github.com/RoaringBitmap/roaring v1.9.4 h1:yhEIoH4YezLYT04s1nHehNO64EKFTop/wBhxv2QzDdQ=
 github.com/RoaringBitmap/roaring v1.9.4/go.mod h1:6AXUsoIEzDTFFQCe1RbGA6uFONMhvejWj5rqITANK90=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
+github.com/antlr4-go/antlr/v4 v4.13.0 h1:lxCg3LAv+EUK6t1i0y1V6/SLeUi0eKEKdhQAlS8TVTI=
+github.com/antlr4-go/antlr/v4 v4.13.0/go.mod h1:pfChB/xh/Unjila75QW7+VU4TSnWnnk9UTnmpPaOR2g=
 github.com/aquasecurity/esquery v0.2.0 h1:9WWXve95TE8hbm3736WB7nS6Owl8UGDeu+0jiyE9ttA=
 github.com/aquasecurity/esquery v0.2.0/go.mod h1:VU+CIFR6C+H142HHZf9RUkp4Eedpo9UrEKeCQHWf9ao=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -252,6 +254,8 @@ github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
 github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60 h1:TfQEwhr0Q9t+Bgs0TNk2eHZ9EGD107Mimic0kcoGS1M=
+github.com/tursodatabase/libsql-client-go v0.0.0-20260528064733-9d5d30a29a60/go.mod h1:08inkKyguB6CGGssc/JzhmQWwBgFQBgjlYFjxjRh7nU=
 github.com/twitchyliquid64/golang-asm v0.15.1 h1:SU5vSMR7hnwNxj24w34ZyCi/FmDZTkS4MhqMhdFk5YI=
 github.com/twitchyliquid64/golang-asm v0.15.1/go.mod h1:a1lVb/DtPvCB8fslRZhAngC2+aY1QWCk3Cedj/Gdt08=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/fiatjaf/eventstore/postgresql"
 	"github.com/fiatjaf/eventstore/slicestore"
 	"github.com/fiatjaf/eventstore/sqlite3"
-	"github.com/fiatjaf/eventstore/turso"
 )
 
 const (
@@ -58,20 +57,6 @@ func TestSQLite(t *testing.T) {
 		os.RemoveAll(dbpath + "sqlite")
 		t.Run(test.name, func(t *testing.T) {
 			test.run(t, &sqlite3.SQLite3Backend{DatabaseURL: dbpath + "sqlite", QueryLimit: 1000, QueryTagsLimit: 50, QueryAuthorsLimit: 2000})
-		})
-	}
-}
-
-func TestTurso(t *testing.T) {
-	// turso is a remote-only backend; it requires a real libsql:// (or https://) URL,
-	// so the test only runs when TURSO_DATABASE_URL is set.
-	url := os.Getenv("TURSO_DATABASE_URL")
-	if url == "" {
-		t.Skip("set TURSO_DATABASE_URL to run the turso test")
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			test.run(t, &turso.TursoBackend{DatabaseURL: url, QueryLimit: 1000, QueryTagsLimit: 50, QueryAuthorsLimit: 2000})
 		})
 	}
 }

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/fiatjaf/eventstore/postgresql"
 	"github.com/fiatjaf/eventstore/slicestore"
 	"github.com/fiatjaf/eventstore/sqlite3"
+	"github.com/fiatjaf/eventstore/turso"
 )
 
 const (
@@ -57,6 +58,20 @@ func TestSQLite(t *testing.T) {
 		os.RemoveAll(dbpath + "sqlite")
 		t.Run(test.name, func(t *testing.T) {
 			test.run(t, &sqlite3.SQLite3Backend{DatabaseURL: dbpath + "sqlite", QueryLimit: 1000, QueryTagsLimit: 50, QueryAuthorsLimit: 2000})
+		})
+	}
+}
+
+func TestTurso(t *testing.T) {
+	// turso is a remote-only backend; it requires a real libsql:// (or https://) URL,
+	// so the test only runs when TURSO_DATABASE_URL is set.
+	url := os.Getenv("TURSO_DATABASE_URL")
+	if url == "" {
+		t.Skip("set TURSO_DATABASE_URL to run the turso test")
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.run(t, &turso.TursoBackend{DatabaseURL: url, QueryLimit: 1000, QueryTagsLimit: 50, QueryAuthorsLimit: 2000})
 		})
 	}
 }

--- a/turso/delete.go
+++ b/turso/delete.go
@@ -7,6 +7,6 @@ import (
 )
 
 func (b *TursoBackend) DeleteEvent(ctx context.Context, evt *nostr.Event) error {
-	_, err := b.DB.ExecContext(ctx, "DELETE FROM event WHERE id = $1", evt.ID)
+	_, err := b.DB.ExecContext(ctx, "DELETE FROM event WHERE id = ?", evt.ID)
 	return err
 }

--- a/turso/delete.go
+++ b/turso/delete.go
@@ -1,0 +1,12 @@
+package turso
+
+import (
+	"context"
+
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func (b *TursoBackend) DeleteEvent(ctx context.Context, evt *nostr.Event) error {
+	_, err := b.DB.ExecContext(ctx, "DELETE FROM event WHERE id = $1", evt.ID)
+	return err
+}

--- a/turso/init.go
+++ b/turso/init.go
@@ -1,0 +1,68 @@
+package turso
+
+import (
+	"github.com/fiatjaf/eventstore"
+	"github.com/jmoiron/sqlx"
+	"github.com/jmoiron/sqlx/reflectx"
+	_ "github.com/tursodatabase/libsql-client-go/libsql"
+)
+
+const (
+	queryLimit        = 100
+	queryIDsLimit     = 500
+	queryAuthorsLimit = 500
+	queryKindsLimit   = 10
+	queryTagsLimit    = 100
+)
+
+var _ eventstore.Store = (*TursoBackend)(nil)
+
+var ddls = []string{
+	`CREATE TABLE IF NOT EXISTS event (
+       id text NOT NULL,
+       pubkey text NOT NULL,
+       created_at integer NOT NULL,
+       kind integer NOT NULL,
+       tags jsonb NOT NULL,
+       content text NOT NULL,
+       sig text NOT NULL);`,
+	`CREATE UNIQUE INDEX IF NOT EXISTS ididx ON event(id)`,
+	`CREATE INDEX IF NOT EXISTS pubkeyprefix ON event(pubkey)`,
+	`CREATE INDEX IF NOT EXISTS timeidx ON event(created_at DESC)`,
+	`CREATE INDEX IF NOT EXISTS kindidx ON event(kind)`,
+	`CREATE INDEX IF NOT EXISTS kindtimeidx ON event(kind,created_at DESC)`,
+}
+
+func (b *TursoBackend) Init() error {
+	db, err := sqlx.Connect("libsql", b.DatabaseURL)
+	if err != nil {
+		return err
+	}
+
+	db.Mapper = reflectx.NewMapperFunc("json", sqlx.NameMapper)
+	b.DB = db
+
+	for _, ddl := range ddls {
+		_, err = b.DB.Exec(ddl)
+		if err != nil {
+			return err
+		}
+	}
+
+	if b.QueryLimit == 0 {
+		b.QueryLimit = queryLimit
+	}
+	if b.QueryIDsLimit == 0 {
+		b.QueryIDsLimit = queryIDsLimit
+	}
+	if b.QueryAuthorsLimit == 0 {
+		b.QueryAuthorsLimit = queryAuthorsLimit
+	}
+	if b.QueryKindsLimit == 0 {
+		b.QueryKindsLimit = queryKindsLimit
+	}
+	if b.QueryTagsLimit == 0 {
+		b.QueryTagsLimit = queryTagsLimit
+	}
+	return nil
+}

--- a/turso/query.go
+++ b/turso/query.go
@@ -1,0 +1,179 @@
+package turso
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func (b *TursoBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (ch chan *nostr.Event, err error) {
+	query, params, err := b.queryEventsSql(filter, false)
+	if err != nil {
+		return nil, err
+	}
+
+	rows, err := b.DB.QueryContext(ctx, query, params...)
+	if err != nil && err != sql.ErrNoRows {
+		return nil, fmt.Errorf("failed to fetch events using query %q: %w", query, err)
+	}
+
+	ch = make(chan *nostr.Event)
+	go func() {
+		defer rows.Close()
+		defer close(ch)
+		for rows.Next() {
+			var evt nostr.Event
+			var timestamp int64
+			err := rows.Scan(&evt.ID, &evt.PubKey, &timestamp,
+				&evt.Kind, &evt.Tags, &evt.Content, &evt.Sig)
+			if err != nil {
+				return
+			}
+			evt.CreatedAt = nostr.Timestamp(timestamp)
+			select {
+			case ch <- &evt:
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+
+	return ch, nil
+}
+
+func (b *TursoBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int64, error) {
+	query, params, err := b.queryEventsSql(filter, true)
+	if err != nil {
+		return 0, err
+	}
+
+	var count int64
+	if err = b.DB.QueryRowContext(ctx, query, params...).Scan(&count); err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("failed to fetch events using query %q: %w", query, err)
+	}
+	return count, nil
+}
+
+var (
+	TooManyIDs       = errors.New("too many ids")
+	TooManyAuthors   = errors.New("too many authors")
+	TooManyKinds     = errors.New("too many kinds")
+	TooManyTagValues = errors.New("too many tag values")
+	EmptyTagSet      = errors.New("empty tag set")
+)
+
+func makePlaceHolders(n int) string {
+	return strings.TrimRight(strings.Repeat("?,", n), ",")
+}
+
+func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+	conditions := make([]string, 0, 7)
+	params := make([]any, 0, 20)
+
+	if len(filter.IDs) > 0 {
+		if len(filter.IDs) > 500 {
+			// too many ids, fail everything
+			return "", nil, TooManyIDs
+		}
+
+		for _, v := range filter.IDs {
+			params = append(params, v)
+		}
+		conditions = append(conditions, `id IN (`+makePlaceHolders(len(filter.IDs))+`)`)
+	}
+
+	if len(filter.Authors) > 0 {
+		if len(filter.Authors) > b.QueryAuthorsLimit {
+			// too many authors, fail everything
+			return "", nil, TooManyAuthors
+		}
+
+		for _, v := range filter.Authors {
+			params = append(params, v)
+		}
+		conditions = append(conditions, `pubkey IN (`+makePlaceHolders(len(filter.Authors))+`)`)
+	}
+
+	if len(filter.Kinds) > 0 {
+		if len(filter.Kinds) > b.QueryKindsLimit {
+			// too many kinds, fail everything
+			return "", nil, TooManyKinds
+		}
+
+		for _, v := range filter.Kinds {
+			params = append(params, v)
+		}
+		conditions = append(conditions, `kind IN (`+makePlaceHolders(len(filter.Kinds))+`)`)
+	}
+
+	// tags
+	totalTags := 0
+	// we use a very bad implementation in which we only check the tag values and ignore the tag names
+	for _, values := range filter.Tags {
+		if len(values) == 0 {
+			// any tag set to [] is wrong
+			return "", nil, EmptyTagSet
+		}
+
+		orTag := make([]string, len(values))
+		for i, tagValue := range values {
+			orTag[i] = `tags LIKE ? ESCAPE '\'`
+			params = append(params, `%`+strings.ReplaceAll(tagValue, `%`, `\%`)+`%`)
+		}
+
+		// each separate tag key is an independent condition
+		conditions = append(conditions, "("+strings.Join(orTag, "OR ")+")")
+
+		totalTags += len(values)
+		if totalTags > b.QueryTagsLimit {
+			// too many tags, fail everything
+			return "", nil, TooManyTagValues
+		}
+	}
+
+	if filter.Since != nil {
+		conditions = append(conditions, `created_at >= ?`)
+		params = append(params, filter.Since)
+	}
+	if filter.Until != nil {
+		conditions = append(conditions, `created_at <= ?`)
+		params = append(params, filter.Until)
+	}
+	if filter.Search != "" {
+		conditions = append(conditions, `content LIKE ? ESCAPE '\'`)
+		params = append(params, `%`+strings.ReplaceAll(filter.Search, `%`, `\%`)+`%`)
+	}
+
+	if len(conditions) == 0 {
+		// fallback
+		conditions = append(conditions, `true`)
+	}
+
+	if filter.Limit < 1 || filter.Limit > b.QueryLimit {
+		params = append(params, b.QueryLimit)
+	} else {
+		params = append(params, filter.Limit)
+	}
+
+	var query string
+	if doCount {
+		query = sqlx.Rebind(sqlx.QUESTION, `SELECT
+          COUNT(*)
+        FROM event WHERE `+
+			strings.Join(conditions, " AND ")+
+			" LIMIT ?")
+	} else {
+		query = sqlx.Rebind(sqlx.QUESTION, `SELECT
+          id, pubkey, created_at, kind, tags, content, sig
+        FROM event WHERE `+
+			strings.Join(conditions, " AND ")+
+			" ORDER BY created_at DESC, id LIMIT ?")
+	}
+
+	return query, params, nil
+}

--- a/turso/replace.go
+++ b/turso/replace.go
@@ -1,0 +1,44 @@
+package turso
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/fiatjaf/eventstore/internal"
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func (b *TursoBackend) ReplaceEvent(ctx context.Context, evt *nostr.Event) error {
+	b.Lock()
+	defer b.Unlock()
+
+	filter := nostr.Filter{Limit: 1, Kinds: []int{evt.Kind}, Authors: []string{evt.PubKey}}
+	if nostr.IsAddressableKind(evt.Kind) {
+		filter.Tags = nostr.TagMap{"d": []string{evt.Tags.GetD()}}
+	}
+
+	ch, err := b.QueryEvents(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("failed to query before replacing: %w", err)
+	}
+
+	shouldStore := true
+	for previous := range ch {
+		if internal.IsOlder(previous, evt) {
+			if err := b.DeleteEvent(ctx, previous); err != nil {
+				return fmt.Errorf("failed to delete event for replacing: %w", err)
+			}
+		} else {
+			shouldStore = false
+		}
+	}
+
+	if shouldStore {
+		if err := b.SaveEvent(ctx, evt); err != nil && err != eventstore.ErrDupEvent {
+			return fmt.Errorf("failed to save: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/turso/save.go
+++ b/turso/save.go
@@ -1,0 +1,32 @@
+package turso
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/nbd-wtf/go-nostr"
+)
+
+func (b *TursoBackend) SaveEvent(ctx context.Context, evt *nostr.Event) error {
+	// insert
+	tagsj, _ := json.Marshal(evt.Tags)
+	res, err := b.DB.ExecContext(ctx, `
+        INSERT OR IGNORE INTO event (id, pubkey, created_at, kind, tags, content, sig)
+        VALUES ($1, $2, $3, $4, $5, $6, $7)
+    `, evt.ID, evt.PubKey, evt.CreatedAt, evt.Kind, tagsj, evt.Content, evt.Sig)
+	if err != nil {
+		return err
+	}
+
+	nr, err := res.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if nr == 0 {
+		return eventstore.ErrDupEvent
+	}
+
+	return nil
+}

--- a/turso/save.go
+++ b/turso/save.go
@@ -11,9 +11,11 @@ import (
 func (b *TursoBackend) SaveEvent(ctx context.Context, evt *nostr.Event) error {
 	// insert
 	tagsj, _ := json.Marshal(evt.Tags)
+	// NOTE: the libsql driver treats $N placeholders as named parameters, which
+	// don't bind to the positional args passed by database/sql, so use ? here.
 	res, err := b.DB.ExecContext(ctx, `
         INSERT OR IGNORE INTO event (id, pubkey, created_at, kind, tags, content, sig)
-        VALUES ($1, $2, $3, $4, $5, $6, $7)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
     `, evt.ID, evt.PubKey, evt.CreatedAt, evt.Kind, tagsj, evt.Content, evt.Sig)
 	if err != nil {
 		return err

--- a/turso/turso.go
+++ b/turso/turso.go
@@ -1,0 +1,22 @@
+package turso
+
+import (
+	"sync"
+
+	"github.com/jmoiron/sqlx"
+)
+
+type TursoBackend struct {
+	sync.Mutex
+	*sqlx.DB
+	DatabaseURL       string
+	QueryLimit        int
+	QueryIDsLimit     int
+	QueryAuthorsLimit int
+	QueryKindsLimit   int
+	QueryTagsLimit    int
+}
+
+func (b *TursoBackend) Close() {
+	b.DB.Close()
+}


### PR DESCRIPTION
Adds a Turso (libsql) eventstore backend. It mirrors the SQLite backend but connects to a remote Turso database via the libsql driver, so it is remote-only (use the existing sqlite3 backend for local files). Includes a guarded test that runs against a real instance when TURSO_DATABASE_URL is set.