### PR TITLE
postgresql, mysql: treat out-of-range created_at/kind filters as no-match

### DIFF
--- a/mysql/query.go
+++ b/mysql/query.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -75,6 +76,7 @@ func escapeLikeString(s string) string {
 func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
+	unsatisfiable := false
 
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > b.QueryIDsLimit {
@@ -106,10 +108,22 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 			return "", nil, nil
 		}
 
+		// kind is a 32-bit integer column, so a kind outside that range can
+		// never match a stored row. Drop those rather than binding a value the
+		// column cannot hold (which fails the whole query with "out of range");
+		// if none remain, nothing can match.
+		kinds := make([]any, 0, len(filter.Kinds))
 		for _, v := range filter.Kinds {
-			params = append(params, v)
+			if v >= math.MinInt32 && v <= math.MaxInt32 {
+				kinds = append(kinds, v)
+			}
 		}
-		conditions = append(conditions, `kind IN (`+makePlaceHolders(len(filter.Kinds))+`)`)
+		if len(kinds) == 0 {
+			unsatisfiable = true
+		} else {
+			params = append(params, kinds...)
+			conditions = append(conditions, `kind IN (`+makePlaceHolders(len(kinds))+`)`)
+		}
 	}
 
 	totalTags := 0
@@ -136,17 +150,38 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 		}
 	}
 
+	// created_at is a 32-bit integer column with the same overflow: a since
+	// above its max (or until below its min) can never match, while a since
+	// below its min (or until above its max) constrains nothing and is dropped.
 	if filter.Since != nil {
-		conditions = append(conditions, `created_at >= ?`)
-		params = append(params, filter.Since)
+		switch since := int64(*filter.Since); {
+		case since > math.MaxInt32:
+			unsatisfiable = true
+		case since >= math.MinInt32:
+			conditions = append(conditions, `created_at >= ?`)
+			params = append(params, filter.Since)
+		}
 	}
 	if filter.Until != nil {
-		conditions = append(conditions, `created_at <= ?`)
-		params = append(params, filter.Until)
+		switch until := int64(*filter.Until); {
+		case until < math.MinInt32:
+			unsatisfiable = true
+		case until <= math.MaxInt32:
+			conditions = append(conditions, `created_at <= ?`)
+			params = append(params, filter.Until)
+		}
 	}
 	if filter.Search != "" {
 		conditions = append(conditions, `content LIKE ?`)
 		params = append(params, `%`+escapeLikeString(filter.Search)+`%`)
+	}
+
+	if unsatisfiable {
+		// a bound the column cannot satisfy: match nothing, but with a valid
+		// query that returns no rows rather than a failed one. Any conditions
+		// and params accumulated above are moot.
+		conditions = []string{"false"}
+		params = params[:0]
 	}
 
 	if len(conditions) == 0 {

--- a/mysql/query_test.go
+++ b/mysql/query_test.go
@@ -1,11 +1,17 @@
 package mysql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/stretchr/testify/require"
 )
+
+func tsPtr(v int64) *nostr.Timestamp {
+	ts := nostr.Timestamp(v)
+	return &ts
+}
 
 func TestQueryEventsSqlBuildsTagValueAlternatives(t *testing.T) {
 	backend := MySQLBackend{
@@ -24,4 +30,71 @@ func TestQueryEventsSqlBuildsTagValueAlternatives(t *testing.T) {
 	require.Contains(t, query, `(tags LIKE ? OR tags LIKE ?)`)
 	require.Contains(t, params, `%["p","pubkey1"%`)
 	require.Contains(t, params, `%["p","pubkey2"%`)
+}
+
+// created_at and kind are 32-bit integer columns; a since/until/kind they cannot
+// hold used to fail the whole query with "out of range" instead of matching
+// nothing. An unreachable bound must yield a valid no-row query (WHERE false),
+// an always-true bound must be dropped, and an out-of-range kind must not reach
+// the backend as a bound value.
+func TestQueryEventsSqlOutOfRangeFilterValues(t *testing.T) {
+	backend := MySQLBackend{
+		QueryLimit:        queryLimit,
+		QueryIDsLimit:     queryIDsLimit,
+		QueryAuthorsLimit: queryAuthorsLimit,
+		QueryKindsLimit:   queryKindsLimit,
+		QueryTagsLimit:    queryTagsLimit,
+	}
+
+	tests := []struct {
+		name          string
+		filter        nostr.Filter
+		unsatisfiable bool // expect WHERE false
+		wantParams    []any
+	}{
+		{
+			name:          "since above column max matches nothing",
+			filter:        nostr.Filter{Since: tsPtr(9_999_999_999)},
+			unsatisfiable: true,
+		},
+		{
+			name:          "until below column min matches nothing",
+			filter:        nostr.Filter{Until: tsPtr(-9_999_999_999)},
+			unsatisfiable: true,
+		},
+		{
+			name:          "all kinds out of range matches nothing",
+			filter:        nostr.Filter{Kinds: []int{9_999_999_999}},
+			unsatisfiable: true,
+		},
+		{
+			name:       "since below column min is dropped",
+			filter:     nostr.Filter{Since: tsPtr(-9_999_999_999)},
+			wantParams: []any{queryLimit},
+		},
+		{
+			name:       "until above column max is dropped",
+			filter:     nostr.Filter{Until: tsPtr(9_999_999_999)},
+			wantParams: []any{queryLimit},
+		},
+		{
+			name:       "out-of-range kind dropped from a mixed list",
+			filter:     nostr.Filter{Kinds: []int{1, 9_999_999_999}},
+			wantParams: []any{1, queryLimit},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			query, params, err := backend.queryEventsSql(tt.filter, false)
+			require.NoError(t, err)
+			if tt.unsatisfiable {
+				require.Contains(t, strings.ReplaceAll(query, " ", ""), "WHEREfalse")
+				require.Equal(t, []any{queryLimit}, params)
+				return
+			}
+			require.NotContains(t, query, "false")
+			require.Equal(t, tt.wantParams, params)
+		})
+	}
 }

--- a/postgresql/query.go
+++ b/postgresql/query.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/jmoiron/sqlx"
@@ -74,6 +75,7 @@ var (
 func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
+	unsatisfiable := false
 
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > b.QueryIDsLimit {
@@ -105,10 +107,22 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 			return "", nil, TooManyKinds
 		}
 
+		// kind is a 32-bit integer column, so a kind outside that range can
+		// never match a stored row. Drop those rather than binding a value the
+		// column cannot hold (which fails the whole query with "out of range
+		// for type integer"); if none remain, nothing can match.
+		kinds := make([]any, 0, len(filter.Kinds))
 		for _, v := range filter.Kinds {
-			params = append(params, v)
+			if v >= math.MinInt32 && v <= math.MaxInt32 {
+				kinds = append(kinds, v)
+			}
 		}
-		conditions = append(conditions, `kind IN (`+makePlaceHolders(len(filter.Kinds))+`)`)
+		if len(kinds) == 0 {
+			unsatisfiable = true
+		} else {
+			params = append(params, kinds...)
+			conditions = append(conditions, `kind IN (`+makePlaceHolders(len(kinds))+`)`)
+		}
 	}
 
 	totalTags := 0
@@ -132,13 +146,26 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 		conditions = append(conditions, `tagvalues && ARRAY[`+makePlaceHolders(len(values))+`]`)
 	}
 
+	// created_at is a 32-bit integer column with the same overflow: a since
+	// above its max (or until below its min) can never match, while a since
+	// below its min (or until above its max) constrains nothing and is dropped.
 	if filter.Since != nil {
-		conditions = append(conditions, `created_at >= ?`)
-		params = append(params, filter.Since)
+		switch since := int64(*filter.Since); {
+		case since > math.MaxInt32:
+			unsatisfiable = true
+		case since >= math.MinInt32:
+			conditions = append(conditions, `created_at >= ?`)
+			params = append(params, filter.Since)
+		}
 	}
 	if filter.Until != nil {
-		conditions = append(conditions, `created_at <= ?`)
-		params = append(params, filter.Until)
+		switch until := int64(*filter.Until); {
+		case until < math.MinInt32:
+			unsatisfiable = true
+		case until <= math.MaxInt32:
+			conditions = append(conditions, `created_at <= ?`)
+			params = append(params, filter.Until)
+		}
 	}
 	if filter.Search != "" {
 		config := b.FullTextSearchConfig
@@ -159,6 +186,14 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 
 		conditions = append(conditions, `to_tsvector(?, `+contentExpr+`) @@ plainto_tsquery(?, ?)`)
 		params = append(params, config, config, filter.Search)
+	}
+
+	if unsatisfiable {
+		// a bound the column cannot satisfy: match nothing, but with a valid
+		// query that returns no rows rather than a failed one. Any conditions
+		// and params accumulated above are moot.
+		conditions = []string{"false"}
+		params = params[:0]
 	}
 
 	if len(conditions) == 0 {

--- a/postgresql/query_test.go
+++ b/postgresql/query_test.go
@@ -1,6 +1,7 @@
 package postgresql
 
 import (
+	"math"
 	"strconv"
 	"strings"
 	"testing"
@@ -8,6 +9,11 @@ import (
 	"github.com/nbd-wtf/go-nostr"
 	"github.com/stretchr/testify/assert"
 )
+
+func tsPtr(v int64) *nostr.Timestamp {
+	ts := nostr.Timestamp(v)
+	return &ts
+}
 
 var defaultBackend = &PostgresBackend{
 	QueryLimit:        queryLimit,
@@ -162,6 +168,86 @@ func TestQueryEventsSql(t *testing.T) {
 			query:  "",
 			params: nil,
 			err:    TooManyTagValues,
+		},
+		// out-of-range created_at / kind: the sql columns are 32-bit integer, so
+		// a value they cannot hold used to fail the whole query with "out of
+		// range for type integer" (22003) instead of matching nothing.
+		{
+			name:    "since above column max matches nothing",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Since: tsPtr(9_999_999_999)},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE false
+			ORDER BY created_at DESC, id LIMIT $1`,
+			params: []any{100},
+			err:    nil,
+		},
+		{
+			name:    "until below column min matches nothing",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Until: tsPtr(-9_999_999_999)},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE false
+			ORDER BY created_at DESC, id LIMIT $1`,
+			params: []any{100},
+			err:    nil,
+		},
+		{
+			name:    "since below column min is dropped",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Since: tsPtr(-9_999_999_999)},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE true
+			ORDER BY created_at DESC, id LIMIT $1`,
+			params: []any{100},
+			err:    nil,
+		},
+		{
+			name:    "until above column max is dropped",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Until: tsPtr(9_999_999_999)},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE true
+			ORDER BY created_at DESC, id LIMIT $1`,
+			params: []any{100},
+			err:    nil,
+		},
+		{
+			name:    "out-of-range kind dropped from a mixed list",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Kinds: []int{1, 9_999_999_999}},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE kind IN ($1)
+			ORDER BY created_at DESC, id LIMIT $2`,
+			params: []any{1, 100},
+			err:    nil,
+		},
+		{
+			name:    "all kinds out of range matches nothing",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Kinds: []int{9_999_999_999}},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE false
+			ORDER BY created_at DESC, id LIMIT $1`,
+			params: []any{100},
+			err:    nil,
+		},
+		{
+			name:    "column boundary values are in range",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Since: tsPtr(math.MinInt32), Until: tsPtr(math.MaxInt32)},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE created_at >= $1 AND created_at <= $2
+			ORDER BY created_at DESC, id LIMIT $3`,
+			params: []any{tsPtr(math.MinInt32), tsPtr(math.MaxInt32), 100},
+			err:    nil,
 		},
 	}
 


### PR DESCRIPTION
`created_at` and `kind` are 32-bit `integer` columns, and `queryEventsSql` binds the raw filter values straight against them. go-nostr decodes `since`/`until` as `int64` and `kinds` as `int` with no range check, so a client sending e.g. `{"since": 9999999999}` or `{"kinds": [9999999999]}` makes postgresql fail the whole query with `out of range for type integer` (22003) instead of returning no rows; mysql overflows the same way.

Because no stored row can hold a value outside the column range, the rewrite is exact rather than approximate:

- `since` > max (or `until` < min) can never match → `WHERE false`, no rows
- `since` < min (or `until` > max) constrains nothing → drop the bound
- an out-of-range `kind` only removes an unmatchable alternative → drop it; if it was the only kind → `WHERE false`

This is handled right next to the existing `EmptyTagSet` / `TooManyIDs` checks. sqlite3 stores `integer` as a dynamic 64-bit type and is unaffected. New table tests cover both bounds of `since`/`until`, `kinds`, and the int32 boundary values themselves; each was verified to fail against the unpatched builder.
