### PR TITLE
postgresql: optional ILIKE substring search (SubstringSearch)

### DIFF
--- a/postgresql/postgresql.go
+++ b/postgresql/postgresql.go
@@ -19,6 +19,7 @@ type PostgresBackend struct {
 	FullTextSearchConfig     string // text search configuration for to_tsvector/to_tsquery, defaults to "simple"
 	FullTextSearchMaxLength  int    // maximum content length for full-text search, 0 means no limit
 	FullTextSearchColumn     string // column to search in, defaults to "content"
+	SubstringSearch          bool   // match NIP-50 search as an ILIKE '%q%' substring instead of tsvector full-text; see queryEventsSql
 }
 
 func (b *PostgresBackend) Close() {

--- a/postgresql/query.go
+++ b/postgresql/query.go
@@ -64,6 +64,15 @@ func makePlaceHolders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
 
+// escapeSearchPattern escapes the LIKE/ILIKE wildcards so a user's search string
+// is matched literally (paired with `ESCAPE '\'`). Used by SubstringSearch.
+func escapeSearchPattern(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
+}
+
 var (
 	TooManyIDs       = errors.New("too many ids")
 	TooManyAuthors   = errors.New("too many authors")
@@ -168,24 +177,37 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 		}
 	}
 	if filter.Search != "" {
-		config := b.FullTextSearchConfig
-		if config == "" {
-			config = "simple"
-		}
 		column := b.FullTextSearchColumn
 		if column == "" {
 			column = "content"
 		}
 
-		var contentExpr string
-		if b.FullTextSearchMaxLength > 0 {
-			contentExpr = fmt.Sprintf("LEFT(%s, %d)", column, b.FullTextSearchMaxLength)
+		if b.SubstringSearch {
+			// Substring match instead of tsvector full-text search. tsvector only
+			// matches whole lexemes at word boundaries, so it misses partial terms
+			// and languages without word separators (e.g. a CJK search for "東京"
+			// never matches a stored "東京都"). ILIKE '%q%' matches any substring;
+			// create a `gin (content gin_trgm_ops)` index (pg_trgm) to keep it fast.
+			// FullTextSearchConfig/MaxLength do not apply in this mode — the raw
+			// column is matched so the trigram index stays usable.
+			conditions = append(conditions, column+` ILIKE ? ESCAPE '\'`)
+			params = append(params, `%`+escapeSearchPattern(filter.Search)+`%`)
 		} else {
-			contentExpr = column
-		}
+			config := b.FullTextSearchConfig
+			if config == "" {
+				config = "simple"
+			}
 
-		conditions = append(conditions, `to_tsvector(?, `+contentExpr+`) @@ plainto_tsquery(?, ?)`)
-		params = append(params, config, config, filter.Search)
+			var contentExpr string
+			if b.FullTextSearchMaxLength > 0 {
+				contentExpr = fmt.Sprintf("LEFT(%s, %d)", column, b.FullTextSearchMaxLength)
+			} else {
+				contentExpr = column
+			}
+
+			conditions = append(conditions, `to_tsvector(?, `+contentExpr+`) @@ plainto_tsquery(?, ?)`)
+			params = append(params, config, config, filter.Search)
+		}
 	}
 
 	if unsatisfiable {

--- a/postgresql/query_test.go
+++ b/postgresql/query_test.go
@@ -23,6 +23,15 @@ var defaultBackend = &PostgresBackend{
 	QueryTagsLimit:    queryTagsLimit,
 }
 
+var substringSearchBackend = &PostgresBackend{
+	QueryLimit:        queryLimit,
+	QueryIDsLimit:     queryIDsLimit,
+	QueryAuthorsLimit: queryAuthorsLimit,
+	QueryKindsLimit:   queryKindsLimit,
+	QueryTagsLimit:    queryTagsLimit,
+	SubstringSearch:   true,
+}
+
 func TestQueryEventsSql(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -247,6 +256,40 @@ func TestQueryEventsSql(t *testing.T) {
 			WHERE created_at >= $1 AND created_at <= $2
 			ORDER BY created_at DESC, id LIMIT $3`,
 			params: []any{tsPtr(math.MinInt32), tsPtr(math.MaxInt32), 100},
+			err:    nil,
+		},
+		// NIP-50 search: tsvector full-text by default, ILIKE substring when opted in.
+		{
+			name:    "search uses tsvector by default",
+			backend: defaultBackend,
+			filter:  nostr.Filter{Search: "hello"},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE to_tsvector($1, content) @@ plainto_tsquery($2, $3)
+			ORDER BY created_at DESC, id LIMIT $4`,
+			params: []any{"simple", "simple", "hello", 100},
+			err:    nil,
+		},
+		{
+			name:    "search uses ILIKE substring when SubstringSearch is set",
+			backend: substringSearchBackend,
+			filter:  nostr.Filter{Search: "東京"},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE content ILIKE $1 ESCAPE '\'
+			ORDER BY created_at DESC, id LIMIT $2`,
+			params: []any{"%東京%", 100},
+			err:    nil,
+		},
+		{
+			name:    "substring search escapes like wildcards",
+			backend: substringSearchBackend,
+			filter:  nostr.Filter{Search: `50%_x`},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE content ILIKE $1 ESCAPE '\'
+			ORDER BY created_at DESC, id LIMIT $2`,
+			params: []any{`%50\%\_x%`, 100},
 			err:    nil,
 		},
 	}


### PR DESCRIPTION
Adds an opt-in `SubstringSearch bool` to `PostgresBackend`. Default is unchanged (tsvector full-text).

tsvector matches whole lexemes at word boundaries, so it misses partial terms and languages without word separators. On a `simple` config a stored `東京都` is a single lexeme, so a NIP-50 search for `東京` never matches — only the exact `東京都` does. The sqlite3 and mysql backends already use `ILIKE`/`LIKE` substring matching, so postgresql is the odd one out here.

When `SubstringSearch` is set the search condition becomes `content ILIKE '%q%'` (wildcards in the user's query escaped, `ESCAPE '\'`). `FullTextSearchConfig`/`MaxLength` don't apply in this mode — the raw column is matched so a trigram index stays usable. Pair it with:

```sql
CREATE INDEX CONCURRENTLY ON event USING gin (content gin_trgm_ops); -- needs pg_trgm
```

Trade-offs vs tsvector (why it's opt-in, not the default): no ranking/stemming, and pg_trgm can't index patterns shorter than 3 chars (they fall back to a seq scan).

Tests cover both the default tsvector path and the substring path, including wildcard escaping.
