### PR TITLE
postgresql: AND whitespace-separated terms in SubstringSearch

### DIFF
--- a/postgresql/query.go
+++ b/postgresql/query.go
@@ -186,12 +186,17 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 			// Substring match instead of tsvector full-text search. tsvector only
 			// matches whole lexemes at word boundaries, so it misses partial terms
 			// and languages without word separators (e.g. a CJK search for "東京"
-			// never matches a stored "東京都"). ILIKE '%q%' matches any substring;
-			// create a `gin (content gin_trgm_ops)` index (pg_trgm) to keep it fast.
-			// FullTextSearchConfig/MaxLength do not apply in this mode — the raw
-			// column is matched so the trigram index stays usable.
-			conditions = append(conditions, column+` ILIKE ? ESCAPE '\'`)
-			params = append(params, `%`+escapeSearchPattern(filter.Search)+`%`)
+			// never matches a stored "東京都"). Each whitespace-separated term must
+			// be present as a substring (AND), mirroring plainto_tsquery's all-terms
+			// semantics, so "東京 京都" matches content containing both. ILIKE '%q%'
+			// matches any substring; create a `gin (content gin_trgm_ops)` index
+			// (pg_trgm) to keep it fast. FullTextSearchConfig/MaxLength do not apply
+			// in this mode — the raw column is matched so the trigram index stays
+			// usable.
+			for _, term := range strings.Fields(filter.Search) {
+				conditions = append(conditions, column+` ILIKE ? ESCAPE '\'`)
+				params = append(params, `%`+escapeSearchPattern(term)+`%`)
+			}
 		} else {
 			config := b.FullTextSearchConfig
 			if config == "" {

--- a/postgresql/query_test.go
+++ b/postgresql/query_test.go
@@ -292,6 +292,17 @@ func TestQueryEventsSql(t *testing.T) {
 			params: []any{`%50\%\_x%`, 100},
 			err:    nil,
 		},
+		{
+			name:    "substring search ANDs each whitespace-separated term",
+			backend: substringSearchBackend,
+			filter:  nostr.Filter{Search: "東京 京都"},
+			query: `SELECT id, pubkey, created_at, kind, tags, content, sig
+			FROM event
+			WHERE content ILIKE $1 ESCAPE '\' AND content ILIKE $2 ESCAPE '\'
+			ORDER BY created_at DESC, id LIMIT $3`,
+			params: []any{"%東京%", "%京都%", 100},
+			err:    nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Follow-up to #72. `SubstringSearch` matched the entire query string as a single `ILIKE '%q%'`, so a multi-word search like `東京 京都` looked for that literal substring (the space included) and missed content that contains both words separately.

Split the search on whitespace and AND one `ILIKE` per term, mirroring `plainto_tsquery`'s all-terms semantics (which the default tsvector path already has). `strings.Fields` also treats the ideographic space (U+3000) as a separator, so full-width-spaced CJK queries work too. Single-term behavior is unchanged.

Test added for the multi-term case.
