### PR TITLE
Count NIP-45 filters as a union in the SQL backends

### DIFF
--- a/mysql/query.go
+++ b/mysql/query.go
@@ -62,6 +62,44 @@ func (b *MySQLBackend) CountEvents(ctx context.Context, filter nostr.Filter) (in
 	return count, nil
 }
 
+// CountEventsFilters counts the events matching any of the filters, counting an
+// event that matches more than one of them only once. NIP-45 OR's the filters
+// together into a single count, so summing a per-filter count would report
+// overlapping filters more than once. The union is evaluated by the database:
+// pulling the ids back to deduplicate them here would cost one id per stored
+// event.
+func (b *MySQLBackend) CountEventsFilters(ctx context.Context, filters nostr.Filters) (int64, error) {
+	switch len(filters) {
+	case 0:
+		return 0, nil
+	case 1:
+		return b.CountEvents(ctx, filters[0])
+	}
+
+	selects := make([]string, 0, len(filters))
+	params := make([]any, 0, len(filters)*20)
+	for _, filter := range filters {
+		conditions, filterParams, err := b.filterConditions(filter)
+		if err != nil {
+			return 0, err
+		}
+		selects = append(selects, "SELECT id FROM event WHERE "+strings.Join(conditions, " AND "))
+		params = append(params, filterParams...)
+	}
+
+	// UNION rather than UNION ALL: the duplicates are exactly the events this
+	// must not count twice. Rebind once, over the whole statement, so the
+	// placeholders are numbered across all the filters.
+	query := sqlx.Rebind(sqlx.BindType("mysql"),
+		"SELECT COUNT(*) FROM ("+strings.Join(selects, " UNION ")+") AS matched")
+
+	var count int64
+	if err := b.DB.QueryRowContext(ctx, query, params...).Scan(&count); err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("failed to count events using query %q: %w", query, err)
+	}
+	return count, nil
+}
+
 func makePlaceHolders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
@@ -73,7 +111,10 @@ func escapeLikeString(s string) string {
 	return s
 }
 
-func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+// filterConditions renders a filter as WHERE conditions and their
+// parameters, without a LIMIT, so that a caller can put the filter
+// somewhere other than a standalone query -- a UNION, say.
+func (b *MySQLBackend) filterConditions(filter nostr.Filter) ([]string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
 	unsatisfiable := false
@@ -81,7 +122,7 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > b.QueryIDsLimit {
 			// too many ids, fail everything
-			return "", nil, nil
+			return nil, nil, nil
 		}
 
 		for _, v := range filter.IDs {
@@ -93,7 +134,7 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(filter.Authors) > 0 {
 		if len(filter.Authors) > b.QueryAuthorsLimit {
 			// too many authors, fail everything
-			return "", nil, nil
+			return nil, nil, nil
 		}
 
 		for _, v := range filter.Authors {
@@ -105,7 +146,7 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(filter.Kinds) > 0 {
 		if len(filter.Kinds) > b.QueryKindsLimit {
 			// too many kinds, fail everything
-			return "", nil, nil
+			return nil, nil, nil
 		}
 
 		// kind is a 32-bit integer column, so a kind outside that range can
@@ -131,7 +172,7 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	for key, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
-			return "", nil, nil
+			return nil, nil, nil
 		}
 
 		orTag := make([]string, 0, len(values))
@@ -146,7 +187,7 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 		totalTags += len(values)
 		if totalTags > b.QueryTagsLimit {
 			// too many tags, fail everything
-			return "", nil, nil
+			return nil, nil, nil
 		}
 	}
 
@@ -187,6 +228,15 @@ func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(conditions) == 0 {
 		// fallback
 		conditions = append(conditions, `true`)
+	}
+
+	return conditions, params, nil
+}
+
+func (b *MySQLBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+	conditions, params, err := b.filterConditions(filter)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if filter.Limit < 1 || filter.Limit > b.QueryLimit {

--- a/postgresql/query.go
+++ b/postgresql/query.go
@@ -60,6 +60,44 @@ func (b *PostgresBackend) CountEvents(ctx context.Context, filter nostr.Filter) 
 	return count, nil
 }
 
+// CountEventsFilters counts the events matching any of the filters, counting an
+// event that matches more than one of them only once. NIP-45 OR's the filters
+// together into a single count, so summing a per-filter count would report
+// overlapping filters more than once. The union is evaluated by PostgreSQL:
+// pulling the ids back to deduplicate them here would cost one id per stored
+// event.
+func (b *PostgresBackend) CountEventsFilters(ctx context.Context, filters nostr.Filters) (int64, error) {
+	switch len(filters) {
+	case 0:
+		return 0, nil
+	case 1:
+		return b.CountEvents(ctx, filters[0])
+	}
+
+	selects := make([]string, 0, len(filters))
+	params := make([]any, 0, len(filters)*20)
+	for _, filter := range filters {
+		conditions, filterParams, err := b.filterConditions(filter)
+		if err != nil {
+			return 0, err
+		}
+		selects = append(selects, "SELECT id FROM event WHERE "+strings.Join(conditions, " AND "))
+		params = append(params, filterParams...)
+	}
+
+	// UNION rather than UNION ALL: the duplicates are exactly the events this
+	// must not count twice. Rebind once, over the whole statement, so the
+	// placeholders are numbered across all the filters.
+	query := sqlx.Rebind(sqlx.BindType("postgres"),
+		"SELECT COUNT(*) FROM ("+strings.Join(selects, " UNION ")+") AS matched")
+
+	var count int64
+	if err := b.DB.QueryRowContext(ctx, query, params...).Scan(&count); err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("failed to count events using query %q: %w", query, err)
+	}
+	return count, nil
+}
+
 func makePlaceHolders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
@@ -81,7 +119,10 @@ var (
 	EmptyTagSet      = errors.New("empty tag set")
 )
 
-func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+// filterConditions renders a filter as WHERE conditions and their
+// parameters, without a LIMIT, so that a caller can put the filter
+// somewhere other than a standalone query -- a UNION, say.
+func (b *PostgresBackend) filterConditions(filter nostr.Filter) ([]string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
 	unsatisfiable := false
@@ -89,7 +130,7 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > b.QueryIDsLimit {
 			// too many ids, fail everything
-			return "", nil, TooManyIDs
+			return nil, nil, TooManyIDs
 		}
 
 		for _, v := range filter.IDs {
@@ -101,7 +142,7 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	if len(filter.Authors) > 0 {
 		if len(filter.Authors) > b.QueryAuthorsLimit {
 			// too many authors, fail everything
-			return "", nil, TooManyAuthors
+			return nil, nil, TooManyAuthors
 		}
 
 		for _, v := range filter.Authors {
@@ -113,7 +154,7 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	if len(filter.Kinds) > 0 {
 		if len(filter.Kinds) > b.QueryKindsLimit {
 			// too many kinds, fail everything
-			return "", nil, TooManyKinds
+			return nil, nil, TooManyKinds
 		}
 
 		// kind is a 32-bit integer column, so a kind outside that range can
@@ -138,13 +179,13 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	for tagKey, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
-			return "", nil, EmptyTagSet
+			return nil, nil, EmptyTagSet
 		}
 
 		totalTags += len(values)
 		if totalTags > b.QueryTagsLimit {
 			// too many tags, fail everything
-			return "", nil, TooManyTagValues
+			return nil, nil, TooManyTagValues
 		}
 
 		for _, tagValue := range values {
@@ -226,6 +267,15 @@ func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (str
 	if len(conditions) == 0 {
 		// fallback
 		conditions = append(conditions, `true`)
+	}
+
+	return conditions, params, nil
+}
+
+func (b *PostgresBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+	conditions, params, err := b.filterConditions(filter)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if filter.Limit < 1 || filter.Limit > b.QueryLimit {

--- a/postgresql/query_test.go
+++ b/postgresql/query_test.go
@@ -338,3 +338,37 @@ func strSlice(n int) []string {
 	}
 	return slice
 }
+
+func TestCountEventsFiltersBuildsAUnion(t *testing.T) {
+	// NIP-45 OR's the filters together, so the ids are UNION'd -- not UNION
+	// ALL'd -- to drop the events that match more than one of them.
+	conditions1, params1, err := defaultBackend.filterConditions(nostr.Filter{Kinds: []int{1}})
+	assert.NoError(t, err)
+	conditions2, params2, err := defaultBackend.filterConditions(nostr.Filter{Kinds: []int{1, 7}})
+	assert.NoError(t, err)
+
+	assert.NotContains(t, strings.Join(conditions1, " "), "LIMIT",
+		"conditions carry no LIMIT of their own")
+	assert.Equal(t, []any{1}, params1)
+	assert.Equal(t, []any{1, 7}, params2)
+
+	// the placeholders have to be numbered across every filter, not restarted
+	// for each one, so the whole statement is rebound at once
+	query := "SELECT COUNT(*) FROM (" +
+		"SELECT id FROM event WHERE " + strings.Join(conditions1, " AND ") + " UNION " +
+		"SELECT id FROM event WHERE " + strings.Join(conditions2, " AND ") + ") AS matched"
+	assert.Equal(t, 3, strings.Count(query, "?"))
+}
+
+func TestFilterConditionsOmitsLimit(t *testing.T) {
+	// queryEventsSql appends the LIMIT parameter itself; filterConditions must
+	// not, or a UNION built from it would bind the wrong values.
+	conditions, params, err := defaultBackend.filterConditions(nostr.Filter{Kinds: []int{1}, Limit: 5})
+	assert.NoError(t, err)
+	assert.Equal(t, []any{1}, params)
+	assert.NotContains(t, strings.Join(conditions, " "), "LIMIT")
+
+	_, sqlParams, err := defaultBackend.queryEventsSql(nostr.Filter{Kinds: []int{1}, Limit: 5}, true)
+	assert.NoError(t, err)
+	assert.Equal(t, []any{1, 5}, sqlParams)
+}

--- a/sqlite3/count_filters_test.go
+++ b/sqlite3/count_filters_test.go
@@ -1,0 +1,60 @@
+package sqlite3
+
+import (
+	"context"
+	"testing"
+
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/assert"
+)
+
+// NIP-45 OR's the filters together, so an event matching more than one of
+// them is counted once. Summing a per-filter count would report it twice.
+func TestCountEventsFiltersCountsTheUnion(t *testing.T) {
+	b := &SQLite3Backend{DatabaseURL: t.TempDir() + "/union.sqlite",
+		QueryLimit: 1000, QueryIDsLimit: 500, QueryAuthorsLimit: 500,
+		QueryKindsLimit: 100, QueryTagsLimit: 100}
+	assert.NoError(t, b.Init())
+	defer b.Close()
+
+	ctx := context.Background()
+	sk := nostr.GeneratePrivateKey()
+	mk := func(kind int, content string) *nostr.Event {
+		ev := &nostr.Event{Kind: kind, Content: content, CreatedAt: nostr.Now(), Tags: nostr.Tags{}}
+		assert.NoError(t, ev.Sign(sk))
+		return ev
+	}
+	for i := 0; i < 3; i++ {
+		assert.NoError(t, b.SaveEvent(ctx, mk(1, string(rune('a'+i)))))
+	}
+	for i := 0; i < 2; i++ {
+		assert.NoError(t, b.SaveEvent(ctx, mk(7, string(rune('x'+i)))))
+	}
+
+	one := nostr.Filter{Kinds: []int{1}}
+	oneAndSeven := nostr.Filter{Kinds: []int{1, 7}}
+	seven := nostr.Filter{Kinds: []int{7}}
+
+	n, err := b.CountEvents(ctx, one)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, n, "single filter")
+
+	// overlapping filters: the union is 5, summing would give 3+5=8
+	n, err = b.CountEventsFilters(ctx, nostr.Filters{one, oneAndSeven})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 5, n, "overlapping filters count each event once")
+
+	// the same filter twice must not double
+	n, err = b.CountEventsFilters(ctx, nostr.Filters{one, one})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, n, "duplicate filters count each event once")
+
+	// disjoint filters: the union equals the sum
+	n, err = b.CountEventsFilters(ctx, nostr.Filters{one, seven})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 5, n, "disjoint filters add up")
+
+	n, err = b.CountEventsFilters(ctx, nostr.Filters{one})
+	assert.NoError(t, err)
+	assert.EqualValues(t, 3, n, "one filter")
+}

--- a/sqlite3/query.go
+++ b/sqlite3/query.go
@@ -59,6 +59,44 @@ func (b *SQLite3Backend) CountEvents(ctx context.Context, filter nostr.Filter) (
 	return count, nil
 }
 
+// CountEventsFilters counts the events matching any of the filters, counting an
+// event that matches more than one of them only once. NIP-45 OR's the filters
+// together into a single count, so summing a per-filter count would report
+// overlapping filters more than once. The union is evaluated by the database:
+// pulling the ids back to deduplicate them here would cost one id per stored
+// event.
+func (b *SQLite3Backend) CountEventsFilters(ctx context.Context, filters nostr.Filters) (int64, error) {
+	switch len(filters) {
+	case 0:
+		return 0, nil
+	case 1:
+		return b.CountEvents(ctx, filters[0])
+	}
+
+	selects := make([]string, 0, len(filters))
+	params := make([]any, 0, len(filters)*20)
+	for _, filter := range filters {
+		conditions, filterParams, err := b.filterConditions(filter)
+		if err != nil {
+			return 0, err
+		}
+		selects = append(selects, "SELECT id FROM event WHERE "+strings.Join(conditions, " AND "))
+		params = append(params, filterParams...)
+	}
+
+	// UNION rather than UNION ALL: the duplicates are exactly the events this
+	// must not count twice. Rebind once, over the whole statement, so the
+	// placeholders are numbered across all the filters.
+	query := sqlx.Rebind(sqlx.BindType("sqlite3"),
+		"SELECT COUNT(*) FROM ("+strings.Join(selects, " UNION ")+") AS matched")
+
+	var count int64
+	if err := b.DB.QueryRowContext(ctx, query, params...).Scan(&count); err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("failed to count events using query %q: %w", query, err)
+	}
+	return count, nil
+}
+
 var (
 	TooManyIDs       = errors.New("too many ids")
 	TooManyAuthors   = errors.New("too many authors")
@@ -71,14 +109,17 @@ func makePlaceHolders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
 
-func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+// filterConditions renders a filter as WHERE conditions and their
+// parameters, without a LIMIT, so that a caller can put the filter
+// somewhere other than a standalone query -- a UNION, say.
+func (b *SQLite3Backend) filterConditions(filter nostr.Filter) ([]string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
 
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > 500 {
 			// too many ids, fail everything
-			return "", nil, TooManyIDs
+			return nil, nil, TooManyIDs
 		}
 
 		for _, v := range filter.IDs {
@@ -90,7 +131,7 @@ func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (stri
 	if len(filter.Authors) > 0 {
 		if len(filter.Authors) > b.QueryAuthorsLimit {
 			// too many authors, fail everything
-			return "", nil, TooManyAuthors
+			return nil, nil, TooManyAuthors
 		}
 
 		for _, v := range filter.Authors {
@@ -102,7 +143,7 @@ func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (stri
 	if len(filter.Kinds) > 0 {
 		if len(filter.Kinds) > b.QueryKindsLimit {
 			// too many kinds, fail everything
-			return "", nil, TooManyKinds
+			return nil, nil, TooManyKinds
 		}
 
 		for _, v := range filter.Kinds {
@@ -117,7 +158,7 @@ func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (stri
 	for _, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
-			return "", nil, EmptyTagSet
+			return nil, nil, EmptyTagSet
 		}
 
 		orTag := make([]string, len(values))
@@ -132,7 +173,7 @@ func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (stri
 		totalTags += len(values)
 		if totalTags > b.QueryTagsLimit {
 			// too many tags, fail everything
-			return "", nil, TooManyTagValues
+			return nil, nil, TooManyTagValues
 		}
 	}
 
@@ -152,6 +193,15 @@ func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (stri
 	if len(conditions) == 0 {
 		// fallback
 		conditions = append(conditions, `true`)
+	}
+
+	return conditions, params, nil
+}
+
+func (b *SQLite3Backend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+	conditions, params, err := b.filterConditions(filter)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if filter.Limit < 1 || filter.Limit > b.QueryLimit {

--- a/turso/query.go
+++ b/turso/query.go
@@ -59,6 +59,44 @@ func (b *TursoBackend) CountEvents(ctx context.Context, filter nostr.Filter) (in
 	return count, nil
 }
 
+// CountEventsFilters counts the events matching any of the filters, counting an
+// event that matches more than one of them only once. NIP-45 OR's the filters
+// together into a single count, so summing a per-filter count would report
+// overlapping filters more than once. The union is evaluated by the database:
+// pulling the ids back to deduplicate them here would cost one id per stored
+// event.
+func (b *TursoBackend) CountEventsFilters(ctx context.Context, filters nostr.Filters) (int64, error) {
+	switch len(filters) {
+	case 0:
+		return 0, nil
+	case 1:
+		return b.CountEvents(ctx, filters[0])
+	}
+
+	selects := make([]string, 0, len(filters))
+	params := make([]any, 0, len(filters)*20)
+	for _, filter := range filters {
+		conditions, filterParams, err := b.filterConditions(filter)
+		if err != nil {
+			return 0, err
+		}
+		selects = append(selects, "SELECT id FROM event WHERE "+strings.Join(conditions, " AND "))
+		params = append(params, filterParams...)
+	}
+
+	// UNION rather than UNION ALL: the duplicates are exactly the events this
+	// must not count twice. Rebind once, over the whole statement, so the
+	// placeholders are numbered across all the filters.
+	query := sqlx.Rebind(sqlx.QUESTION,
+		"SELECT COUNT(*) FROM ("+strings.Join(selects, " UNION ")+") AS matched")
+
+	var count int64
+	if err := b.DB.QueryRowContext(ctx, query, params...).Scan(&count); err != nil && err != sql.ErrNoRows {
+		return 0, fmt.Errorf("failed to count events using query %q: %w", query, err)
+	}
+	return count, nil
+}
+
 var (
 	TooManyIDs       = errors.New("too many ids")
 	TooManyAuthors   = errors.New("too many authors")
@@ -71,14 +109,17 @@ func makePlaceHolders(n int) string {
 	return strings.TrimRight(strings.Repeat("?,", n), ",")
 }
 
-func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+// filterConditions renders a filter as WHERE conditions and their
+// parameters, without a LIMIT, so that a caller can put the filter
+// somewhere other than a standalone query -- a UNION, say.
+func (b *TursoBackend) filterConditions(filter nostr.Filter) ([]string, []any, error) {
 	conditions := make([]string, 0, 7)
 	params := make([]any, 0, 20)
 
 	if len(filter.IDs) > 0 {
 		if len(filter.IDs) > 500 {
 			// too many ids, fail everything
-			return "", nil, TooManyIDs
+			return nil, nil, TooManyIDs
 		}
 
 		for _, v := range filter.IDs {
@@ -90,7 +131,7 @@ func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(filter.Authors) > 0 {
 		if len(filter.Authors) > b.QueryAuthorsLimit {
 			// too many authors, fail everything
-			return "", nil, TooManyAuthors
+			return nil, nil, TooManyAuthors
 		}
 
 		for _, v := range filter.Authors {
@@ -102,7 +143,7 @@ func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(filter.Kinds) > 0 {
 		if len(filter.Kinds) > b.QueryKindsLimit {
 			// too many kinds, fail everything
-			return "", nil, TooManyKinds
+			return nil, nil, TooManyKinds
 		}
 
 		for _, v := range filter.Kinds {
@@ -117,7 +158,7 @@ func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	for _, values := range filter.Tags {
 		if len(values) == 0 {
 			// any tag set to [] is wrong
-			return "", nil, EmptyTagSet
+			return nil, nil, EmptyTagSet
 		}
 
 		orTag := make([]string, len(values))
@@ -132,7 +173,7 @@ func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 		totalTags += len(values)
 		if totalTags > b.QueryTagsLimit {
 			// too many tags, fail everything
-			return "", nil, TooManyTagValues
+			return nil, nil, TooManyTagValues
 		}
 	}
 
@@ -152,6 +193,15 @@ func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string
 	if len(conditions) == 0 {
 		// fallback
 		conditions = append(conditions, `true`)
+	}
+
+	return conditions, params, nil
+}
+
+func (b *TursoBackend) queryEventsSql(filter nostr.Filter, doCount bool) (string, []any, error) {
+	conditions, params, err := b.filterConditions(filter)
+	if err != nil {
+		return "", nil, err
 	}
 
 	if filter.Limit < 1 || filter.Limit > b.QueryLimit {


### PR DESCRIPTION
[NIP-45](https://github.com/nostr-protocol/nips/blob/master/45.md) says:

> This NIP defines the verb `COUNT`, which accepts a query id and filters as specified in [NIP 01](01.md) for the verb `REQ`. Multiple filters are OR'd together and aggregated into a single count result.

OR'd together is a union, so an event matching more than one filter belongs to it once. A caller can only sum `CountEvents` per filter, which counts that event once per filter it matches. The sum is exact when the filters do not overlap and too high when they do.

Add `CountEventsFilters` to the four SQL backends, counting over a UNION of the per-filter id selects so the database drops the duplicates. Deduplicating in the caller instead would cost one id per stored event.

`queryEventsSql` is split so the conditions can be reused outside a standalone query; the statement is rebound once, over the whole UNION, so the placeholders are numbered across every filter rather than restarting at each one.

The other backends are untouched and remain exact for filters that do not overlap.

Verified against a real SQLite database (`sqlite3/count_filters_test.go`) with 3 kind-1 and 2 kind-7 events:

| filters | union | summing |
|---|---|---|
| `{kinds:[1]}` | 3 | 3 |
| `{kinds:[1]}` + `{kinds:[1,7]}` | 5 | 8 |
| `{kinds:[1]}` twice | 3 | 6 |
| `{kinds:[1]}` + `{kinds:[7]}` | 5 | 5 |
