### PR TITLE
badger, lmdb: match tag values exactly, and check every tag of a filter

### DIFF
--- a/badger/query_planner.go
+++ b/badger/query_planner.go
@@ -83,10 +83,13 @@ func prepareQueries(filter nostr.Filter) (
 			i++
 		}
 
+		// the indexed tag stays in the extra filter: for plain string values (and the "d" part of "a" values) the index key
+		// is the value itself with nothing after it, so a query for "a" also walks the keys of "a-b", "abc" and so on
+		// (https://github.com/fiatjaf/khatru/issues/52). the exact match is done against the fetched event below.
 		extraFilter = &nostr.Filter{
 			Kinds:   filter.Kinds,
 			Authors: filter.Authors,
-			Tags:    internal.CopyMapWithoutKey(filter.Tags, tagKey),
+			Tags:    filter.Tags,
 		}
 
 		return queries, extraFilter, since, nil

--- a/lmdb/count.go
+++ b/lmdb/count.go
@@ -17,7 +17,7 @@ import (
 func (b *LMDBBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int64, error) {
 	var count int64 = 0
 
-	queries, extraAuthors, extraKinds, extraTagKey, extraTagValues, since, err := b.prepareQueries(filter)
+	queries, extraAuthors, extraKinds, extraTags, since, err := b.prepareQueries(filter)
 	if err != nil {
 		return 0, err
 	}
@@ -50,7 +50,7 @@ func (b *LMDBBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int
 					}
 				}
 
-				if extraAuthors == nil && extraKinds == nil && extraTagValues == nil {
+				if extraAuthors == nil && extraKinds == nil && len(extraTags) == 0 {
 					count++
 				} else {
 					// fetch actual event
@@ -78,7 +78,7 @@ func (b *LMDBBackend) CountEvents(ctx context.Context, filter nostr.Filter) (int
 					}
 
 					// if there is still a tag to be checked, do it now
-					if !evt.Tags.ContainsAny(extraTagKey, extraTagValues) {
+					if !tagsMatch(extraTags, evt) {
 						it.next()
 						continue
 					}
@@ -103,7 +103,7 @@ func (b *LMDBBackend) CountEventsHLL(ctx context.Context, filter nostr.Filter, o
 	var count int64 = 0
 
 	// this is different than CountEvents because some of these extra checks are not applicable in HLL-valid filters
-	queries, _, extraKinds, extraTagKey, extraTagValues, since, err := b.prepareQueries(filter)
+	queries, _, extraKinds, extraTags, since, err := b.prepareQueries(filter)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -144,7 +144,7 @@ func (b *LMDBBackend) CountEventsHLL(ctx context.Context, filter nostr.Filter, o
 					panic(err)
 				}
 
-				if extraKinds == nil && extraTagValues == nil {
+				if extraKinds == nil && len(extraTags) == 0 {
 					// nothing extra to check
 					count++
 					hll.AddBytes(val[32:64])
@@ -162,7 +162,7 @@ func (b *LMDBBackend) CountEventsHLL(ctx context.Context, filter nostr.Filter, o
 					}
 
 					// if there is still a tag to be checked, do it now
-					if !evt.Tags.ContainsAny(extraTagKey, extraTagValues) {
+					if !tagsMatch(extraTags, evt) {
 						it.next()
 						continue
 					}

--- a/lmdb/query.go
+++ b/lmdb/query.go
@@ -58,7 +58,7 @@ func (b *LMDBBackend) QueryEvents(ctx context.Context, filter nostr.Filter) (cha
 }
 
 func (b *LMDBBackend) query(txn *lmdb.Txn, filter nostr.Filter, limit int) ([]internal.IterEvent, error) {
-	queries, extraAuthors, extraKinds, extraTagKey, extraTagValues, since, err := b.prepareQueries(filter)
+	queries, extraAuthors, extraKinds, extraTags, since, err := b.prepareQueries(filter)
 	if err != nil {
 		return nil, err
 	}
@@ -180,8 +180,8 @@ func (b *LMDBBackend) query(txn *lmdb.Txn, filter nostr.Filter, limit int) ([]in
 
 				// fmt.Println("      event", hex.EncodeToString(val[0:4]), "kind", binary.BigEndian.Uint16(val[132:134]), "author", hex.EncodeToString(val[32:36]), "ts", nostr.Timestamp(binary.BigEndian.Uint32(val[128:132])), hex.EncodeToString(it.key), it.valIdx)
 
-				// if there is still a tag to be checked, do it now
-				if extraTagValues != nil && !event.Tags.ContainsAny(extraTagKey, extraTagValues) {
+				// check every tag of the filter against the event, the indexed one included
+				if !tagsMatch(extraTags, event) {
 					it.next()
 					continue
 				}
@@ -407,4 +407,13 @@ func (b *LMDBBackend) query(txn *lmdb.Txn, filter nostr.Filter, limit int) ([]in
 	}
 
 	return combinedResults, nil
+}
+
+func tagsMatch(tags nostr.TagMap, event *nostr.Event) bool {
+	for key, values := range tags {
+		if len(values) > 0 && !event.Tags.ContainsAny(key, values) {
+			return false
+		}
+	}
+	return true
 }

--- a/lmdb/query_planner.go
+++ b/lmdb/query_planner.go
@@ -24,8 +24,7 @@ func (b *LMDBBackend) prepareQueries(filter nostr.Filter) (
 	queries []query,
 	extraAuthors [][32]byte,
 	extraKinds [][2]byte,
-	extraTagKey string,
-	extraTagValues []string,
+	extraTags nostr.TagMap,
 	since uint32,
 	err error,
 ) {
@@ -55,15 +54,15 @@ func (b *LMDBBackend) prepareQueries(filter nostr.Filter) (
 		queries = make([]query, len(filter.IDs))
 		for i, idHex := range filter.IDs {
 			if len(idHex) != 64 {
-				return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid id '%s'", idHex)
+				return nil, nil, nil, nil, 0, fmt.Errorf("invalid id '%s'", idHex)
 			}
 			prefix := make([]byte, 8)
 			if _, err := hex.Decode(prefix[0:8], []byte(idHex[0:8*2])); err != nil {
-				return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid id '%s'", idHex)
+				return nil, nil, nil, nil, 0, fmt.Errorf("invalid id '%s'", idHex)
 			}
 			queries[i] = query{i: i, dbi: b.indexId, prefix: prefix[0:8], keySize: 8, timestampSize: 0}
 		}
-		return queries, nil, nil, "", nil, 0, nil
+		return queries, nil, nil, nil, 0, nil
 	}
 
 	// this is where we'll end the iteration
@@ -90,13 +89,13 @@ func (b *LMDBBackend) prepareQueries(filter nostr.Filter) (
 				queries = make([]query, len(tagValues)*len(filter.Kinds))
 				for _, value := range tagValues {
 					if len(value) != 64 {
-						return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
+						return nil, nil, nil, nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
 					}
 
 					for _, kind := range filter.Kinds {
 						k := make([]byte, 8+2)
 						if _, err := hex.Decode(k[0:8], []byte(value[0:8*2])); err != nil {
-							return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
+							return nil, nil, nil, nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
 						}
 						binary.BigEndian.PutUint16(k[8:8+2], uint16(kind))
 						queries[i] = query{i: i, dbi: b.indexPTagKind, prefix: k[0 : 8+2], keySize: 8 + 2 + 4, timestampSize: 4}
@@ -108,12 +107,12 @@ func (b *LMDBBackend) prepareQueries(filter nostr.Filter) (
 				queries = make([]query, len(tagValues))
 				for i, value := range tagValues {
 					if len(value) != 64 {
-						return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
+						return nil, nil, nil, nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
 					}
 
 					k := make([]byte, 8)
 					if _, err := hex.Decode(k[0:8], []byte(value[0:8*2])); err != nil {
-						return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
+						return nil, nil, nil, nil, 0, fmt.Errorf("invalid 'p' tag '%s'", value)
 					}
 					queries[i] = query{i: i, dbi: b.indexPTagKind, prefix: k[0:8], keySize: 8 + 2 + 4, timestampSize: 4}
 				}
@@ -147,13 +146,14 @@ func (b *LMDBBackend) prepareQueries(filter nostr.Filter) (
 			}
 		}
 
-		// add an extra useless tag if available
-		filter.Tags = internal.CopyMapWithoutKey(filter.Tags, tagKey)
+		// every tag is checked against the fetched event, the indexed one included: for plain string values (and the
+		// "d" part of "a" values) the index key is the value itself with nothing after it, so a query for "a" also walks
+		// the keys of "a-b", "abc" and so on (https://github.com/fiatjaf/khatru/issues/52)
 		if len(filter.Tags) > 0 {
-			extraTagKey, extraTagValues, _ = internal.ChooseNarrowestTag(filter)
+			extraTags = filter.Tags
 		}
 
-		return queries, extraAuthors, extraKinds, extraTagKey, extraTagValues, since, nil
+		return queries, extraAuthors, extraKinds, extraTags, since, nil
 	}
 
 pubkeyMatching:
@@ -163,11 +163,11 @@ pubkeyMatching:
 			queries = make([]query, len(filter.Authors))
 			for i, pubkeyHex := range filter.Authors {
 				if len(pubkeyHex) != 64 {
-					return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
+					return nil, nil, nil, nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
 				}
 				prefix := make([]byte, 8)
 				if _, err := hex.Decode(prefix[0:8], []byte(pubkeyHex[0:8*2])); err != nil {
-					return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
+					return nil, nil, nil, nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
 				}
 				queries[i] = query{i: i, dbi: b.indexPubkey, prefix: prefix[0:8], keySize: 8 + 4, timestampSize: 4}
 			}
@@ -178,11 +178,11 @@ pubkeyMatching:
 			for _, pubkeyHex := range filter.Authors {
 				for _, kind := range filter.Kinds {
 					if len(pubkeyHex) != 64 {
-						return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
+						return nil, nil, nil, nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
 					}
 					prefix := make([]byte, 8+2)
 					if _, err := hex.Decode(prefix[0:8], []byte(pubkeyHex[0:8*2])); err != nil {
-						return nil, nil, nil, "", nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
+						return nil, nil, nil, nil, 0, fmt.Errorf("invalid author '%s'", pubkeyHex)
 					}
 					binary.BigEndian.PutUint16(prefix[8:8+2], uint16(kind))
 					queries[i] = query{i: i, dbi: b.indexPubkeyKind, prefix: prefix[0 : 8+2], keySize: 10 + 4, timestampSize: 4}
@@ -191,9 +191,11 @@ pubkeyMatching:
 			}
 		}
 
-		// potentially with an extra useless tag filtering
-		extraTagKey, extraTagValues, _ = internal.ChooseNarrowestTag(filter)
-		return queries, nil, nil, extraTagKey, extraTagValues, since, nil
+		// every tag in the filter is checked against the fetched event
+		if len(filter.Tags) > 0 {
+			extraTags = filter.Tags
+		}
+		return queries, nil, nil, extraTags, since, nil
 	}
 
 	if len(filter.Kinds) > 0 {
@@ -205,14 +207,16 @@ pubkeyMatching:
 			queries[i] = query{i: i, dbi: b.indexKind, prefix: prefix[0:2], keySize: 2 + 4, timestampSize: 4}
 		}
 
-		// potentially with an extra useless tag filtering
-		tagKey, tagValues, _ := internal.ChooseNarrowestTag(filter)
-		return queries, nil, nil, tagKey, tagValues, since, nil
+		// every tag in the filter is checked against the fetched event
+		if len(filter.Tags) > 0 {
+			extraTags = filter.Tags
+		}
+		return queries, nil, nil, extraTags, since, nil
 	}
 
 	// if we got here our query will have nothing to filter with
 	queries = make([]query, 1)
 	prefix := make([]byte, 0)
 	queries[0] = query{i: 0, dbi: b.indexCreatedAt, prefix: prefix, keySize: 0 + 4, timestampSize: 4}
-	return queries, nil, nil, "", nil, since, nil
+	return queries, nil, nil, nil, since, nil
 }

--- a/test/db_test.go
+++ b/test/db_test.go
@@ -30,6 +30,7 @@ var tests = []struct {
 	{"second", runSecondTestOn},
 	{"manyauthors", manyAuthorsTest},
 	{"unbalanced", unbalancedTest},
+	{"tagprefix", tagPrefixTest},
 }
 
 func TestSliceStore(t *testing.T) {

--- a/test/tagprefix_test.go
+++ b/test/tagprefix_test.go
@@ -1,0 +1,82 @@
+package test
+
+import (
+	"testing"
+
+	"github.com/fiatjaf/eventstore"
+	"github.com/nbd-wtf/go-nostr"
+	"github.com/stretchr/testify/require"
+)
+
+// a tag value must match exactly, not as a prefix of a longer value.
+// this is the bug behind https://github.com/fiatjaf/khatru/issues/52: with "a-b" stored first and newer,
+// publishing an addressable event with d="a" was silently dropped because the replace query for d="a"
+// also matched "a-b" through the undelimited index key.
+func tagPrefixTest(t *testing.T, db eventstore.Store) {
+	err := db.Init()
+	require.NoError(t, err)
+
+	w := eventstore.RelayWrapper{Store: db}
+	pk, err := nostr.GetPublicKey(sk3)
+	require.NoError(t, err)
+
+	mk := func(kind int, ts int, tags nostr.Tags) *nostr.Event {
+		evt := &nostr.Event{CreatedAt: nostr.Timestamp(ts), Kind: kind, Content: "x", Tags: tags}
+		evt.Sign(sk3)
+		return evt
+	}
+
+	// an addressable event whose d tag is a prefix of another one's, published after it and older than it
+	ab := mk(30023, 200, nostr.Tags{{"d", "a-b"}})
+	a := mk(30023, 100, nostr.Tags{{"d", "a"}})
+	require.NoError(t, w.Publish(ctx, *ab))
+	require.NoError(t, w.Publish(ctx, *a))
+
+	for _, f := range []nostr.Filter{
+		{Kinds: []int{30023}, Authors: []string{pk}, Tags: nostr.TagMap{"d": {"a"}}},
+		{Tags: nostr.TagMap{"d": {"a"}}},
+	} {
+		res, err := w.QuerySync(ctx, f)
+		require.NoError(t, err)
+		require.Len(t, res, 1, "filter %v", f)
+		require.Equal(t, a.ID, res[0].ID, "filter %v", f)
+	}
+	res, err := w.QuerySync(ctx, nostr.Filter{Tags: nostr.TagMap{"d": {"a-b"}}})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, ab.ID, res[0].ID)
+
+	// the same for "a" tags pointing at those addresses and for plain string tags
+	refA := mk(1, 300, nostr.Tags{{"a", "30023:" + pk + ":a"}})
+	refAB := mk(1, 301, nostr.Tags{{"a", "30023:" + pk + ":a-b"}})
+	tagA := mk(1, 302, nostr.Tags{{"t", "nostr"}})
+	tagAB := mk(1, 303, nostr.Tags{{"t", "nostrdev"}})
+	for _, evt := range []*nostr.Event{refA, refAB, tagA, tagAB} {
+		require.NoError(t, db.SaveEvent(ctx, evt))
+	}
+	res, err = w.QuerySync(ctx, nostr.Filter{Tags: nostr.TagMap{"a": {"30023:" + pk + ":a"}}})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, refA.ID, res[0].ID)
+	res, err = w.QuerySync(ctx, nostr.Filter{Kinds: []int{1}, Tags: nostr.TagMap{"t": {"nostr"}}})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, tagA.ID, res[0].ID)
+
+	// when a filter has two tag conditions both must hold
+	res, err = w.QuerySync(ctx, nostr.Filter{Authors: []string{pk}, Tags: nostr.TagMap{"t": {"nostr"}, "a": {"30023:" + pk + ":a"}}})
+	require.NoError(t, err)
+	require.Len(t, res, 0)
+
+	// also when both tags are ones the planner has no index preference for, so the author index is used
+	xy := mk(1, 304, nostr.Tags{{"x", "1"}, {"y", "1"}})
+	xOnly := mk(1, 305, nostr.Tags{{"x", "1"}})
+	yOnly := mk(1, 306, nostr.Tags{{"y", "1"}})
+	for _, evt := range []*nostr.Event{xy, xOnly, yOnly} {
+		require.NoError(t, db.SaveEvent(ctx, evt))
+	}
+	res, err = w.QuerySync(ctx, nostr.Filter{Authors: []string{pk}, Tags: nostr.TagMap{"x": {"1"}, "y": {"1"}}})
+	require.NoError(t, err)
+	require.Len(t, res, 1)
+	require.Equal(t, xy.ID, res[0].ID)
+}


### PR DESCRIPTION
This is the bug behind fiatjaf/khatru#52 (the "silent rejection of certain replaceable events"), plus a smaller lmdb gap found while writing the test.

**badger.** For plain string tag values, and for the `d` part of `a`-style values, the tag index key is the value itself with nothing after it, so a prefix iteration for `d=a` also walks the keys of `a-b`, `abc` and so on. The planner then dropped the indexed tag from the post-fetch `extraFilter` (`CopyMapWithoutKey`), trusting the index to be exact. So with `a-b` stored first and newer, publishing an addressable event with `d=a` was silently not stored: the replace query for `d=a` returned the `a-b` event, `IsOlder` said the new one was older, and `shouldStore` went false with no error. Plain tag queries had the same false positives. Fix: the indexed tag stays in `extraFilter.Tags`, so `filterMatchesTags` checks the fetched event for the exact value. No index format change, no migration.

**lmdb.** Its keys are already exact for these cases, so it did not have the `d=a` bug. But when a filter has authors or kinds and two tags the planner has no index preference for (the `default` branch of `ChooseNarrowestTag`), `prepareQueries` returned only one extra tag and the other was never enforced. It now returns the whole `TagMap`, and the query and both count paths check every tag against the fetched event (`tagsMatch`).

**test.** `tagPrefixTest` runs on every backend from `test/db_test.go`: `d=a` next to `d=a-b` through `RelayWrapper.Publish`, `a` tags pointing at those addresses, plain `t` tags, a two-condition filter, and a two-unknown-tags filter. Without the change it fails on badger at the `d=a` query and on lmdb at the two-unknown-tags query; with it, `TestSliceStore`, `TestBadger` and `TestLMDB` pass.

Cost: one tag scan per fetched candidate on tag queries, which were already decoding the event.

A length-prefixed or terminated badger index key would remove the false positives at the iterator level instead; that needs a migration, so it is left out of this PR, happy to follow up if you prefer that shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
