### PR TITLE
badger: fix index-out-of-range panic on tags shorter than 2 elements

### DIFF
--- a/badger/helpers.go
+++ b/badger/helpers.go
@@ -103,7 +103,23 @@ func (b *BadgerBackend) getIndexKeysForEvent(evt *nostr.Event, idx []byte) iter.
 		customSkip := b.SkipIndexingTag != nil
 
 		for i, tag := range evt.Tags {
-			if len(tag) < 2 || len(tag[0]) != 1 || len(tag[1]) == 0 || len(tag[1]) > 100 {
+			// A tag with fewer than 2 elements (e.g. NIP-70's bare ["-"]
+			// protected-event marker) has no tag[1] at all. Go evaluates
+			// call arguments before the call, so passing tag[1] straight
+			// into IndexLongerTag below -- inside the very branch this
+			// length check exists to guard -- panicked with an
+			// out-of-range index before IndexLongerTag's own body (which
+			// does handle a short/empty value safely) ever ran. Since
+			// IndexLongerTag is wired for every event a relay stores, not
+			// just ones it authors itself, any client publishing any
+			// event containing a bare single-element tag would crash the
+			// whole process. Checked separately, before ever touching
+			// tag[1], rather than folded back into the compound condition
+			// below.
+			if len(tag) < 2 {
+				continue
+			}
+			if len(tag[0]) != 1 || len(tag[1]) == 0 || len(tag[1]) > 100 {
 				if !customIndex || !b.IndexLongerTag(evt, tag[0], tag[1]) {
 					// not indexable
 					continue


### PR DESCRIPTION
## Summary
- A tag with fewer than 2 elements (e.g. NIP-70's bare `["-"]` protected-event marker) has no `tag[1]`. The `len(tag) < 2` check correctly short-circuits the rest of its compound OR condition, but the branch it falls into then unconditionally evaluates `tag[1]` as a call argument to `IndexLongerTag` — Go evaluates call arguments before the call, so this panics with an out-of-range index before `IndexLongerTag`'s own body (which does handle a short/empty value safely) ever runs.
- Not hypothetical: once `IndexLongerTag` is configured, it's wired for every event a relay stores, not just ones it authors — so any client publishing any event with a bare single-element tag crashes the whole process.
- Fixed by checking `len(tag) < 2` on its own, before ever touching `tag[1]`, rather than folded into the compound condition that still (correctly) short-circuits on it but doesn't stop the later unconditional call.

## Test plan
- Reproduced the panic directly (a relay configured with `IndexLongerTag`, an event containing a bare single-element tag) before applying the fix, confirmed it no longer panics after.
- `go build`, `go vet`, `gofmt -l` all clean.